### PR TITLE
Fix incorrect WebSocket import path in orders API

### DIFF
--- a/backend/app/api/v1/endpoints/orders.py
+++ b/backend/app/api/v1/endpoints/orders.py
@@ -15,7 +15,7 @@ from app.api.v1.endpoints.auth import get_current_user, User
 from app.core.redis_client import get_redis, RedisClient
 from app.core.responses import APIResponseHelper
 from app.core.exceptions import FynloException, ErrorCodes
-from app.websocket.manager import websocket_manager
+from app.core.websocket import websocket_manager
 
 router = APIRouter()
 


### PR DESCRIPTION
Changed import from 'app.websocket.manager' to 'app.core.websocket' to match the actual location of the WebSocket manager after consolidation. This resolves import errors preventing orders API from loading.

🤖 Generated with [Claude Code](https://claude.ai/code)