### PR TITLE
Fix Pydantic Settings configuration error blocking startup

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     APP_NAME: str = "Fynlo POS"
     DEBUG: bool = True
     API_V1_STR: str = "/api/v1"
+    ENVIRONMENT: str = "development"
     
     # Database
     DATABASE_URL: str = "postgresql://fynlo_user:fynlo_password@localhost:5432/fynlo_pos"


### PR DESCRIPTION
Added missing ENVIRONMENT field to Settings class that was causing 'Extra inputs are not permitted' validation error. This was preventing the backend from starting at all.

🤖 Generated with [Claude Code](https://claude.ai/code)