### PR TITLE
Add missing AUTHENTICATION_ERROR code to ErrorCodes class

### DIFF
--- a/backend/app/core/responses.py
+++ b/backend/app/core/responses.py
@@ -277,6 +277,7 @@ class ErrorCodes:
     """Standardized error codes for iOS app handling"""
     
     # Authentication errors
+    AUTHENTICATION_ERROR = "AUTHENTICATION_ERROR"
     INVALID_CREDENTIALS = "INVALID_CREDENTIALS"
     TOKEN_EXPIRED = "TOKEN_EXPIRED"
     TOKEN_INVALID = "TOKEN_INVALID"


### PR DESCRIPTION
This error code is referenced in mobile endpoints but was missing from the ErrorCodes class definition. Adding it ensures consistency across the authentication system.

🤖 Generated with [Claude Code](https://claude.ai/code)