### PR TITLE
Fix critical startup issue: Add missing __init__.py files

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,7 @@
+"""
+Fynlo POS Backend Application
+FastAPI-based Point of Sale system for restaurants
+"""
+
+__version__ = "1.0.0"
+__author__ = "Ryan Davidson"

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,4 @@
+"""
+API package for Fynlo POS
+Contains all API route definitions and endpoints
+"""

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,0 +1,4 @@
+"""
+API v1 package
+Version 1 of the Fynlo POS API
+"""

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -1,0 +1,4 @@
+"""
+API v1 endpoints package
+Contains all endpoint implementations for API version 1
+"""

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,4 @@
+"""
+Core package for Fynlo POS
+Contains core functionality, database models, and utilities
+"""

--- a/backend/app/websocket/__init__.py
+++ b/backend/app/websocket/__init__.py
@@ -1,0 +1,4 @@
+"""
+WebSocket package
+Alternative WebSocket implementation for real-time communication
+"""


### PR DESCRIPTION
ISSUE FIXED: Missing package structure prevented Python imports
- Added app/__init__.py - Main application package
- Added app/api/__init__.py - API package
- Added app/api/v1/__init__.py - API v1 package
- Added app/api/v1/endpoints/__init__.py - Endpoints package
- Added app/core/__init__.py - Core functionality package
- Added app/websocket/__init__.py - WebSocket package

IMPACT:
- Backend can now start without import errors
- Python can properly recognize all packages
- Resolves ModuleNotFoundError issues

TESTING: Backend startup should now work with proper imports

🤖 Generated with [Claude Code](https://claude.ai/code)