### PR TITLE
Fix: Resolve TypeError in service charge configuration

### DIFF
--- a/backend/app/models/platform_config.py
+++ b/backend/app/models/platform_config.py
@@ -250,6 +250,40 @@ DEFAULT_PLATFORM_CONFIGS = [
         'category': 'business_rules',
         'description': 'Maximum service charge restaurants can apply',
     },
+
+    # Service Charge Configuration
+    {
+        'config_key': 'platform.service_charge.enabled',
+        'config_value': {'value': True}, # Storing as a dict to match other config_value structures
+        'category': 'service_charge',
+        'description': 'Enable or disable platform-wide service charge.',
+        'is_sensitive': False,
+        'validation_schema': {'type': 'object', 'properties': {'value': {'type': 'boolean'}}}
+    },
+    {
+        'config_key': 'platform.service_charge.rate',
+        'config_value': {'value': 12.5}, # Storing as a dict
+        'category': 'service_charge',
+        'description': 'Service charge rate as a percentage (e.g., 12.5 for 12.5%).',
+        'is_sensitive': False,
+        'validation_schema': {'type': 'object', 'properties': {'value': {'type': 'number', 'minimum': 0, 'maximum': 100}}}
+    },
+    {
+        'config_key': 'platform.service_charge.description',
+        'config_value': {'value': 'Platform service charge'}, # Storing as a dict
+        'category': 'service_charge',
+        'description': 'Description for the service charge (e.g., for display on receipts).',
+        'is_sensitive': False,
+        'validation_schema': {'type': 'object', 'properties': {'value': {'type': 'string', 'maxLength': 255}}}
+    },
+    {
+        'config_key': 'platform.service_charge.currency',
+        'config_value': {'value': 'GBP'}, # Storing as a dict
+        'category': 'service_charge',
+        'description': 'Currency for the service charge.',
+        'is_sensitive': False,
+        'validation_schema': {'type': 'object', 'properties': {'value': {'type': 'string', 'enum': ['GBP', 'USD', 'EUR']}}}
+    },
 ]
 
 # Default feature flags


### PR DESCRIPTION
This commit addresses a critical TypeError that occurred during platform owner sign-in due to issues with loading service charge configuration.

The main changes include:
1.  Defined default configurations for service charge settings (enabled, rate, description, currency) in `platform_config.py` and ensured they are initialized by `initialize_platform_defaults.py` and the corresponding service method.
2.  Modified `PlatformSettingsService` to include:
    - `get_service_charge_config()`: Retrieves all service charge settings and formats them into the required nested structure. Crucially, it includes fallback logic to use the defined defaults if any configuration key is missing from the database, preventing TypeErrors.
    - `update_service_charge_config()`: Allows updating all service charge settings through a single method.
3.  Added new dedicated API endpoints in `platform_settings.py`:
    - `GET /api/v1/platform/service-charge`: Retrieves the consolidated service charge configuration.
    - `PUT /api/v1/platform/service-charge`: Updates the service charge configuration. Both endpoints require admin authentication.
4.  The existing `/settings/bulk-update` endpoint can still be used to update individual service charge keys, provided the payload config_value is in the `{'value': ...}` format.
5.  Added a new test file `backend/test_platform_settings_service_charge.py` with unit tests for the service methods and integration tests for the new API endpoints. Tests cover successful operations, error handling, authentication, and the fallback mechanism for missing data.

These changes ensure that the service charge configuration is always available in a well-structured format during platform owner sign-in, resolving the TypeError and allowing platform owners to authenticate successfully.