### PR TITLE
feat: Add comprehensive security headers middleware

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     # File Upload
     MAX_FILE_SIZE: int = 10 * 1024 * 1024  # 10MB
     UPLOAD_DIR: str = "uploads"
+
+    # CORS
+    PRODUCTION_ALLOWED_ORIGINS: list[str] = ["https://your-production-frontend.com"] # TODO: Update with actual frontend domain
     
     class Config:
         case_sensitive = True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.core.mobile_middleware import (
     MobileDataOptimizationMiddleware
 )
 from app.middleware.version_middleware import APIVersionMiddleware
+from app.middleware.security_headers_middleware import SecurityHeadersMiddleware # Added import
 from datetime import datetime
 
 # Configure logging
@@ -65,17 +66,27 @@ app = FastAPI(
 )
 
 # CORS middleware for React Native frontend
+if settings.ENVIRONMENT == "production":
+    allowed_origins = settings.PRODUCTION_ALLOWED_ORIGINS
+else:
+    allowed_origins = ["*"] # Permissive for development
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure for production
+    allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["*"], # Can be restricted further if needed e.g. ["GET", "POST", "PUT", "DELETE"]
+    allow_headers=["*"], # Can be restricted further e.g. ["Content-Type", "Authorization"]
 )
 
 # Add API version middleware for backward compatibility (FIRST in middleware stack)
 # This must be added before other middleware to ensure path rewriting happens first
 app.add_middleware(APIVersionMiddleware)
+
+# Add Security Headers Middleware (after CORS and Versioning, before others)
+# Ensure this import is added at the top of the file:
+# from app.middleware.security_headers_middleware import SecurityHeadersMiddleware
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Add mobile compatibility middleware
 app.add_middleware(MobileCompatibilityMiddleware, enable_cors=True, enable_port_redirect=True)

--- a/backend/app/middleware/security_headers_middleware.py
+++ b/backend/app/middleware/security_headers_middleware.py
@@ -1,0 +1,113 @@
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseCallNext
+from app.core.config import settings
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseCallNext) -> Response:
+        response = await call_next(request)
+
+        # Common headers for all environments
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block" # Deprecated but still good for older browsers
+
+        if settings.ENVIRONMENT == "production":
+            # Production specific headers
+            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
+            response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+            # CSP needs careful configuration, will be more complex
+            response.headers["Content-Security-Policy"] = self.get_production_csp()
+            response.headers["Permissions-Policy"] = self.get_permissions_policy()
+        else:
+            # Development/staging specific headers (more permissive)
+            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains" # Can be less strict if not preloading
+            response.headers["Referrer-Policy"] = "no-referrer-when-downgrade" # More permissive
+            response.headers["Content-Security-Policy"] = self.get_development_csp()
+            response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()" # Example, adjust as needed
+
+        return response
+
+    def get_production_csp(self):
+        # Base policy: restrict to self, allow necessary scripts and styles
+        # This needs to be carefully configured based on actual needs, especially for payment providers
+        # and WebSocket connections.
+        # Example: default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline'; ...
+        # For WebSockets: connect-src 'self' wss://yourdomain.com;
+
+        # Start with a restrictive policy
+        csp_directives = {
+            "default-src": ["'self'"],
+            "script-src": ["'self'", "https://js.stripe.com", "https://checkout.stripe.com"], # Stripe JS
+            "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"], # Allow inline styles for now, and Google Fonts
+            "img-src": ["'self'", "data:", "https://*.stripe.com"], # Allow data URIs and Stripe images
+            "font-src": ["'self'", "https://fonts.gstatic.com"], # Google Fonts
+            "connect-src": [
+                "'self'",
+                # "wss://" + settings.DOMAIN if hasattr(settings, 'DOMAIN') and settings.DOMAIN else "", # WebSocket - Re-evaluate how to best set this
+                "https://api.stripe.com",
+                "https://errors.stripe.com"
+            ], # Allow self, WebSocket, Stripe API
+            "frame-src": ["'self'", "https://js.stripe.com", "https://checkout.stripe.com"], # Stripe frames
+            "object-src": ["'none'"], # Disallow plugins like Flash
+            "base-uri": ["'self'"],
+            "form-action": ["'self'"], # Restrict where forms can submit
+            "frame-ancestors": ["'none'"], # Equivalent to X-Frame-Options: DENY
+            # "report-uri": ["/api/v1/csp-reports"], # Endpoint to report violations (optional) - needs an endpoint
+        }
+
+        # CSP directives for connect-src might need to be adjusted based on settings.DOMAIN availability
+        # For now, WebSocket connections to a different domain than 'self' might be blocked in production.
+        # Consider adding settings.DOMAIN or making CSP more dynamically configurable.
+
+        return "; ".join([f"{key} {' '.join(values)}" for key, values in csp_directives.items() if values])
+
+    def get_development_csp(self):
+        # More permissive CSP for development to avoid blocking common dev tools
+        # Still, it's good practice to keep it as close to production as possible
+        csp_directives = {
+            "default-src": ["'self'"],
+            "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://js.stripe.com", "https://checkout.stripe.com"], # Allow inline scripts and eval for dev
+            "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+            "img-src": ["'self'", "data:", "https://*.stripe.com"],
+            "font-src": ["'self'", "https://fonts.gstatic.com"],
+            "connect-src": [
+                "'self'",
+                "ws://localhost:8000", # Local WebSocket
+                "wss://localhost:8000", # Local secure WebSocket
+                "http://localhost:8000", # Local HTTP for API calls
+                "https://api.stripe.com",
+                "https://errors.stripe.com"
+            ],
+            "frame-src": ["'self'", "https://js.stripe.com", "https://checkout.stripe.com"],
+            "object-src": ["'none'"],
+            "base-uri": ["'self'"],
+            "form-action": ["'self'"],
+            "frame-ancestors": ["'self'"], # Allow framing from self for dev tools
+        }
+        return "; ".join([f"{key} {' '.join(values)}" for key, values in csp_directives.items()])
+
+    def get_permissions_policy(self):
+        # Define features and their permissions
+        # Example: geolocation=(self "https://example.com"), microphone=()
+        # By default, disable most features unless explicitly needed.
+        permissions = [
+            "accelerometer=()",
+            "ambient-light-sensor=()",
+            "autoplay=()",
+            "camera=()", # Example: allow self if app needs camera: "camera=(self)"
+            "encrypted-media=()",
+            "fullscreen=(self)", # Example: allow self if app needs fullscreen
+            "geolocation=()", # Example: "geolocation=(self \"https://trusted.third-party.com\")"
+            "gyroscope=()",
+            "magnetometer=()",
+            "microphone=()",
+            "midi=()",
+            "payment=()", # Example: "payment=(self \"https://stripe.com\")" if Stripe handles payments in an iframe
+            "picture-in-picture=()",
+            "speaker=()",
+            "sync-xhr=(self)",
+            "usb=()",
+            "vr=()",
+            "screen-wake-lock=()"
+        ]
+        return ", ".join(permissions)


### PR DESCRIPTION
- Implemented middleware to add critical security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy).
- Configured headers to be environment-specific ( stricter for production).
- Hardened CORS configuration to restrict allowed origins in production.
- Added placeholders and TODOs for production-specific configurations (allowed origins, CSP for WebSockets).