### PR TITLE
feat: Add DigitalOcean App Platform spec

### DIFF
--- a/backend/deploy/spec.yaml
+++ b/backend/deploy/spec.yaml
@@ -1,0 +1,83 @@
+# DigitalOcean App Spec for Fynlo POS Backend
+name: fynlo-pos-backend
+region: lon # London region, as specified for the database
+
+# Define the services
+services:
+  - name: api
+    # Build from Dockerfile
+    dockerfile_path: backend/Dockerfile
+    source_dir: ./
+    github:
+      # Replace with your actual repo and branch
+      repo: <YOUR_GITHUB_USERNAME_OR_ORG>/<YOUR_REPO_NAME>
+      branch: main # Or your deployment branch
+    # Environment variables
+    envs:
+      - key: API_HOST
+        value: "0.0.0.0"
+      - key: API_PORT
+        value: "8000" # App Platform will map this to 80/443 externally
+      - key: API_RELOAD
+        value: "false"
+      - key: DATABASE_URL
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET # Mark as secret, value to be set in App Platform UI
+      - key: REDIS_URL
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET # Mark as secret, value to be set in App Platform UI
+      # Add any other non-secret environment variables from your .env file here
+      # For example:
+      # - key: SOME_OTHER_CONFIG
+      #   value: "some_value"
+    instance_size_slug: basic-xxs # Start with a small instance size
+    instance_count: 1
+    # HTTP routes
+    routes:
+      - path: / # Route all traffic to this service
+    # Health check
+    health_check:
+      http_path: /health # Path defined in Dockerfile HEALTHCHECK
+      initial_delay_seconds: 30
+      period_seconds: 10
+      timeout_seconds: 5
+      failure_threshold: 3
+      success_threshold: 1
+    # Port for the service to listen on internally
+    http_port: 8000
+
+# Define jobs that run during deployment
+jobs:
+  - name: migrate
+    kind: PRE_DEPLOY # Run before deploying the 'api' service
+    # Build from Dockerfile (same as api service)
+    dockerfile_path: backend/Dockerfile
+    source_dir: ./
+    github:
+      # Replace with your actual repo and branch
+      repo: <YOUR_GITHUB_USERNAME_OR_ORG>/<YOUR_REPO_NAME>
+      branch: main # Or your deployment branch
+    # Command to run for migrations
+    run_command: alembic upgrade head
+    # Environment variables for the job (needs database access)
+    envs:
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        type: SECRET
+      # Add any other envs required by alembic, if they are different from the main service
+    instance_size_slug: basic-xxs # Migrations usually don't need large instances
+
+# Optional: Define databases, static sites, etc.
+# For this deployment, databases are already provisioned.
+
+# Alerting (optional, configure in DigitalOcean UI or add spec here)
+# alerts:
+# - rule: DEPLOYMENT_FAILED
+# - rule: DOMAIN_FAILED
+
+# Custom domain (optional, configure in DigitalOcean UI or add spec here)
+# domains:
+# - domain: your-app-custom-domain.com
+#   type: PRIMARY # or ALIAS
+#   zone: your-app-custom-domain.com # if using DigitalOcean DNS
+#   minimum_tls_version: "1.2"


### PR DESCRIPTION
This commit introduces the app.yaml specification file for deploying the FastAPI backend to DigitalOcean App Platform.

The spec includes:
- Service definition for the API.
- Pre-deploy job for running Alembic database migrations.
- Configuration for environment variables (secrets to be set in DO UI).
- Health check configuration.

This file will be used to create and configure the application on the DigitalOcean App Platform.