### PR TITLE
Fix: Prevent dev icon from showing in production builds

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/screens/main/POSScreen.tsx
+++ b/CashApp-iOS/CashAppPOS/src/screens/main/POSScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { IS_DEV } from '../../env'; // Import IS_DEV
 import {
   StyleSheet,
   Text,
@@ -648,15 +649,18 @@ const POSScreen: React.FC = () => {
               <Icon name="qr-code-scanner" size={24} color={theme.colors.white} />
             </TouchableOpacity>
             
-            <TouchableOpacity
-              style={[styles.cartButton, { marginRight: 8 }]}
-              onPress={() => {
-                setShowSumUpTest(!showSumUpTest);
-                console.log('🧪 SumUp Test toggled:', !showSumUpTest);
-              }}
-            >
-              <Icon name="bug-report" size={20} color={theme.colors.white} />
-            </TouchableOpacity>
+            {IS_DEV && FLAGS.SHOW_DEV_MENU && (
+              <TouchableOpacity
+                testID="dev-mode-toggle-button"
+                style={[styles.cartButton, { marginRight: 8 }]}
+                onPress={() => {
+                  setShowSumUpTest(!showSumUpTest);
+                  console.log('🧪 SumUp Test toggled:', !showSumUpTest);
+                }}
+              >
+                <Icon name="bug-report" size={20} color={theme.colors.white} />
+              </TouchableOpacity>
+            )}
             
             <TouchableOpacity
               style={styles.cartButton}

--- a/CashApp-iOS/CashAppPOS/src/screens/main/__tests__/POSScreen.test.tsx
+++ b/CashApp-iOS/CashAppPOS/src/screens/main/__tests__/POSScreen.test.tsx
@@ -292,3 +292,69 @@ describe('POSScreen', () => {
     expect(getByText('$30.97')).toBeTruthy();
   });
 });
+
+// New tests for Header Actions conditional rendering
+describe('POSScreen Header Actions Conditional Rendering', () => {
+  // Mock FLAGS, assuming it would be globally available or imported in a real scenario
+  const mockFlagsBase = {
+    SHOW_DEV_MENU: true,
+  };
+
+  // Mock the env module
+  let mockIS_DEV: boolean;
+  jest.mock('../../../../src/env', () => ({
+    get IS_DEV() { return mockIS_DEV; }, // Use a getter to allow dynamic changes
+    envBool: jest.fn((name, fallback) => fallback), // Mock other exports if necessary
+  }));
+
+  beforeEach(() => {
+    // Reset mocks and global FLAGS before each test in this suite
+    jest.clearAllMocks();
+    // @ts-ignore: Assigning to global for test purposes
+    global.FLAGS = { ...mockFlagsBase };
+  });
+
+  it('should not render bug icon in production when FLAGS.SHOW_DEV_MENU is true', () => {
+    mockIS_DEV = false; // Simulate production environment
+    // @ts-ignore: Assigning to global for test purposes
+    global.FLAGS.SHOW_DEV_MENU = true;
+
+    const { queryByTestId, toJSON } = customRenderWithStores(<POSScreen />, { navigationProps: { navigation: mockNavigation } });
+
+    expect(queryByTestId('dev-mode-toggle-button')).toBeNull();
+    expect(toJSON()).toMatchSnapshot(); // Snapshot for overall structure
+  });
+
+  it('should render bug icon in development when FLAGS.SHOW_DEV_MENU is true', () => {
+    mockIS_DEV = true; // Simulate development environment
+    // @ts-ignore: Assigning to global for test purposes
+    global.FLAGS.SHOW_DEV_MENU = true;
+
+    const { getByTestId, toJSON } = customRenderWithStores(<POSScreen />, { navigationProps: { navigation: mockNavigation } });
+
+    expect(getByTestId('dev-mode-toggle-button')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot(); // Snapshot for overall structure
+  });
+
+  it('should not render bug icon if FLAGS.SHOW_DEV_MENU is false, even in development', () => {
+    mockIS_DEV = true; // Simulate development environment
+    // @ts-ignore: Assigning to global for test purposes
+    global.FLAGS.SHOW_DEV_MENU = false;
+
+    const { queryByTestId, toJSON } = customRenderWithStores(<POSScreen />, { navigationProps: { navigation: mockNavigation } });
+
+    expect(queryByTestId('dev-mode-toggle-button')).toBeNull();
+    expect(toJSON()).toMatchSnapshot(); // Snapshot for overall structure
+  });
+
+  it('should not render bug icon if FLAGS.SHOW_DEV_MENU is false in production', () => {
+    mockIS_DEV = false; // Simulate production environment
+    // @ts-ignore: Assigning to global for test purposes
+    global.FLAGS.SHOW_DEV_MENU = false;
+
+    const { queryByTestId, toJSON } = customRenderWithStores(<POSScreen />, { navigationProps: { navigation: mockNavigation } });
+
+    expect(queryByTestId('dev-mode-toggle-button')).toBeNull();
+    expect(toJSON()).toMatchSnapshot(); // Snapshot for overall structure
+  });
+});


### PR DESCRIPTION
This commit addresses an issue where a development-related icon (a bug icon used for toggling SumUp tests) was unintentionally visible in production builds of the CashAppPOS iOS app.

Changes made:

1.  **Located Icon Code:** Identified the `TouchableOpacity` component rendering the bug icon within `CashApp-iOS/CashAppPOS/src/screens/main/POSScreen.tsx`.
2.  **Conditional Rendering:** Modified `POSScreen.tsx` to conditionally render the icon based on `IS_DEV && FLAGS.SHOW_DEV_MENU`.
    *   Imported `IS_DEV` from `CashApp-iOS/CashAppPOS/src/env.ts`.
    *   Added `testID="dev-mode-toggle-button"` to the icon's `TouchableOpacity` for easier testing.
3.  **Unit Tests:** Added snapshot tests to `CashApp-iOS/CashAppPOS/src/screens/main/__tests__/POSScreen.test.tsx`. These tests cover:
    *   Icon not rendering in production (IS_DEV=false).
    *   Icon rendering in development (IS_DEV=true, FLAGS.SHOW_DEV_MENU=true).
    *   Icon not rendering when FLAGS.SHOW_DEV_MENU is false (regardless of IS_DEV).

Outstanding Items & Challenges:

*   **ESLint Rule:** The plan included adding an ESLint rule (`no-restricted-globals`) to prevent accidental usage of dev-only components without proper guards. However, I was unable to definitively locate the ESLint configuration file (`.eslintrc.js` or `.eslintrc.json`). This rule still needs to be added once the file location is confirmed. The proposed rule was:
    `"no-restricted-globals": ["error", { "name": "DevModeToggle", "message": "Use only behind __DEV__ guard" }]`
    (The `name` would need adjustment based on the actual component/global being restricted).
*   **Test Execution & Snapshots:** I encountered significant difficulties executing the Jest unit tests successfully within the provided environment. Issues included `cd` commands not behaving as expected across tool calls and Jest failing to find the `react-native` preset despite various attempts to specify the correct configuration and working directory. The new snapshots for `POSScreen.test.tsx` need to be generated, and the tests confirmed to pass by someone with access to a working local environment for this project.
*   **`FLAGS` Object Origin:** The implemented fix and tests assume `FLAGS` is a globally available object containing `SHOW_DEV_MENU`. If `FLAGS` or `SHOW_DEV_MENU` needs to be imported or accessed differently, `POSScreen.tsx` and its tests will require adjustments.

These outstanding items will need to be addressed to fully complete and verify the fix.