### PR TITLE
🚨 HOTFIX: Fix JSONB import error causing deployment failure

### DIFF
--- a/backend/app/models/subscriptions.py
+++ b/backend/app/models/subscriptions.py
@@ -1,5 +1,6 @@
 # app/models/subscriptions.py
-from sqlalchemy import Column, Integer, String, DECIMAL, Boolean, JSONB, ForeignKey, TIMESTAMP
+from sqlalchemy import Column, Integer, String, DECIMAL, Boolean, ForeignKey, TIMESTAMP
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 from app.core.database import Base
 


### PR DESCRIPTION
## 🚨 Critical Production Hotfix

This PR fixes a critical import error that's preventing the backend from starting on DigitalOcean.

## 🐛 Issue
The deployment was failing with:
```
ImportError: cannot import name 'JSONB' from 'sqlalchemy'
```

## 🔧 Solution
- Import JSONB from PostgreSQL dialect instead of base SQLAlchemy
- Changed: `from sqlalchemy import ... JSONB`
- To: `from sqlalchemy.dialects.postgresql import JSONB`

## 📋 Changes
- Fixed import statement in `backend/app/models/subscriptions.py`
- JSONB is PostgreSQL-specific and must be imported from the dialect module

## 🧪 Testing
- Import error resolved
- JSONB type now properly imported for PostgreSQL
- Ready for deployment

## 🚀 Deployment Impact
This fix is required for the backend to start properly on DigitalOcean.

🤖 Generated with Claude Code