### PR TITLE
Fix missing await in async function

### DIFF
--- a/backend/app/api/v1/platform/financial.py
+++ b/backend/app/api/v1/platform/financial.py
@@ -124,7 +124,7 @@ async def get_revenue_report(
         }
         
         # Cache for 1 hour
-        cache_data(cache_key, summary, ttl=3600)
+        await cache_data(cache_key, summary, ttl=3600)
         
         return APIResponseHelper.success(data=summary)
         


### PR DESCRIPTION
Add `await` keyword to `cache_data` call to prevent runtime error.