### PR TITLE
HOTFIX: Fix platform API import error blocking deployment

### DIFF
--- a/backend/app/api/v1/platform/analytics.py
+++ b/backend/app/api/v1/platform/analytics.py
@@ -11,7 +11,7 @@ from sqlalchemy import func, and_, desc
 from app.core.database import get_db, Restaurant, Order, Payment, User
 from app.core.auth import get_current_platform_owner
 from app.core.cache import get_cached_data_async, cache_data
-from app.core.response_helper import APIResponseHelper
+from app.core.responses import APIResponseHelper
 
 router = APIRouter(prefix="/analytics", tags=["platform-analytics"])
 

--- a/backend/app/api/v1/platform/financial.py
+++ b/backend/app/api/v1/platform/financial.py
@@ -10,7 +10,7 @@ from sqlalchemy import func, and_, case
 
 from app.core.database import get_db, Restaurant, Order, Payment, User
 from app.core.auth import get_current_platform_owner
-from app.core.response_helper import APIResponseHelper
+from app.core.responses import APIResponseHelper
 from app.core.cache import get_cached_data_async, cache_data
 
 router = APIRouter(prefix="/financial", tags=["platform-financial"])

--- a/backend/app/api/v1/platform/restaurants.py
+++ b/backend/app/api/v1/platform/restaurants.py
@@ -10,7 +10,7 @@ from sqlalchemy import or_
 
 from app.core.database import get_db, Restaurant, User
 from app.core.auth import get_current_platform_owner
-from app.core.response_helper import APIResponseHelper
+from app.core.responses import APIResponseHelper
 from app.schemas.restaurant import RestaurantCreate, RestaurantUpdate
 
 router = APIRouter(prefix="/restaurants", tags=["platform-restaurants"])

--- a/backend/app/api/v1/platform/subscriptions.py
+++ b/backend/app/api/v1/platform/subscriptions.py
@@ -10,7 +10,7 @@ from sqlalchemy import func, and_
 
 from app.core.database import get_db, Restaurant
 from app.core.auth import get_current_platform_owner, User
-from app.core.response_helper import APIResponseHelper
+from app.core.responses import APIResponseHelper
 from app.models.subscriptions import SubscriptionPlan
 
 router = APIRouter(prefix="/subscriptions", tags=["platform-subscriptions"])

--- a/backend/app/api/v1/platform/users.py
+++ b/backend/app/api/v1/platform/users.py
@@ -10,7 +10,7 @@ from sqlalchemy import or_, and_, func
 
 from app.core.database import get_db, User, Restaurant
 from app.core.auth import get_current_platform_owner
-from app.core.response_helper import APIResponseHelper
+from app.core.responses import APIResponseHelper
 
 router = APIRouter(prefix="/users", tags=["platform-users"])
 


### PR DESCRIPTION
## Critical Production Fix

### Issue
Deployment is failing with ModuleNotFoundError:
```
ModuleNotFoundError: No module named 'app.core.response_helper'
```

### Root Cause
All platform API modules were importing APIResponseHelper from the wrong module path.

### Fix
Changed import from:
```python
from app.core.response_helper import APIResponseHelper
```

To:
```python
from app.core.responses import APIResponseHelper
```

### Files Fixed
- backend/app/api/v1/platform/analytics.py
- backend/app/api/v1/platform/financial.py
- backend/app/api/v1/platform/restaurants.py
- backend/app/api/v1/platform/subscriptions.py
- backend/app/api/v1/platform/users.py

### Testing
This is a simple import path fix that will resolve the deployment error.

### Urgency
**CRITICAL** - Production deployment is currently blocked