### PR TITLE
HOTFIX: Add missing restaurant schema and fix imports

### DIFF
--- a/backend/app/api/v1/platform/subscriptions.py
+++ b/backend/app/api/v1/platform/subscriptions.py
@@ -11,7 +11,7 @@ from sqlalchemy import func, and_
 from app.core.database import get_db, Restaurant
 from app.core.auth import get_current_platform_owner, User
 from app.core.responses import APIResponseHelper
-from app.models.subscriptions import SubscriptionPlan
+from app.models.subscription import SubscriptionPlan
 
 router = APIRouter(prefix="/subscriptions", tags=["platform-subscriptions"])
 

--- a/backend/app/schemas/restaurant.py
+++ b/backend/app/schemas/restaurant.py
@@ -1,0 +1,73 @@
+"""
+Restaurant schemas for Fynlo POS
+"""
+
+from typing import Optional, Dict, Any, List
+from datetime import datetime
+from pydantic import BaseModel, EmailStr
+
+
+class RestaurantBase(BaseModel):
+    """Base restaurant schema"""
+    name: str
+    address: dict
+    phone: Optional[str] = None
+    email: Optional[EmailStr] = None
+    timezone: str = "UTC"
+    business_hours: dict = {}
+    settings: dict = {}
+
+
+class RestaurantCreate(RestaurantBase):
+    """Schema for creating a restaurant"""
+    pass
+
+
+class RestaurantUpdate(BaseModel):
+    """Schema for updating a restaurant"""
+    name: Optional[str] = None
+    address: Optional[dict] = None
+    phone: Optional[str] = None
+    email: Optional[EmailStr] = None
+    timezone: Optional[str] = None
+    business_hours: Optional[dict] = None
+    settings: Optional[dict] = None
+    tax_configuration: Optional[dict] = None
+    payment_methods: Optional[dict] = None
+    is_active: Optional[bool] = None
+
+
+class RestaurantResponse(RestaurantBase):
+    """Schema for restaurant responses"""
+    id: str
+    platform_id: Optional[str]
+    tax_configuration: dict
+    payment_methods: dict
+    is_active: bool
+    created_at: datetime
+    updated_at: Optional[datetime]
+
+    class Config:
+        from_attributes = True
+
+
+class RestaurantStats(BaseModel):
+    """Restaurant statistics schema"""
+    restaurant_id: str
+    name: str
+    daily_revenue: float
+    monthly_revenue: float
+    total_orders: int
+    active_customers: int
+    average_order_value: float
+    payment_method_breakdown: dict
+
+
+class PlatformStats(BaseModel):
+    """Platform statistics schema"""
+    total_restaurants: int
+    active_restaurants: int
+    total_revenue: float
+    total_orders: int
+    total_customers: int
+    top_performing_restaurants: List[RestaurantStats]


### PR DESCRIPTION
## Critical Production Fix #2

### Issue
Deployment is failing with ModuleNotFoundError:
```
ModuleNotFoundError: No module named 'app.schemas.restaurant'
```

### Root Cause
1. Restaurant schemas were not in a separate schema file - they were defined inline in the endpoints
2. Wrong import path for subscription model

### Fix
1. Created `app/schemas/restaurant.py` with all required restaurant schemas:
   - RestaurantBase
   - RestaurantCreate
   - RestaurantUpdate
   - RestaurantResponse
   - RestaurantStats
   - PlatformStats

2. Fixed import from `app.models.subscriptions` to `app.models.subscription`

### Testing
These are straightforward import fixes that will resolve the deployment errors.

### Urgency
**CRITICAL** - Production deployment is still blocked