### PR TITLE
fix: add Request parameter to rate-limited export endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/exports.py
+++ b/backend/app/api/v1/endpoints/exports.py
@@ -5,7 +5,7 @@ TEMPORARILY DISABLED DUE TO MISSING DEPENDENCIES
 
 from typing import Optional
 from datetime import date
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db, User
@@ -18,6 +18,7 @@ router = APIRouter()
 @router.get("/menu/{restaurant_id}/export")
 @limiter.limit(PORTAL_EXPORT_RATE)
 async def export_menu_disabled(
+    request: Request,
     restaurant_id: str,
     format: str = Query("json", regex="^(json|csv|pdf)$"),
     db: Session = Depends(get_db),
@@ -32,6 +33,7 @@ async def export_menu_disabled(
 @router.get("/reports/{restaurant_id}/export")
 @limiter.limit(PORTAL_EXPORT_RATE)
 async def export_report_disabled(
+    request: Request,
     restaurant_id: str,
     report_type: str = Query(..., regex="^(sales|inventory|staff|customers|financial)$"),
     format: str = Query("json", regex="^(json|csv|pdf)$"),
@@ -49,6 +51,7 @@ async def export_report_disabled(
 @router.post("/menu/{restaurant_id}/import")
 @limiter.limit(PORTAL_EXPORT_RATE)
 async def import_menu_disabled(
+    request: Request,
     restaurant_id: str,
     file_content: dict,  # JSON content from request body
     db: Session = Depends(get_db),


### PR DESCRIPTION
## 🚨 Critical Fix for Backend Deployment

### Problem
Backend deployment is failing with:
```
Exception: No "request" or "websocket" argument on function "<function export_menu_disabled at 0x7ef8913a7b00>"
```

### Root Cause
The SlowAPI rate limiter decorator `@limiter.limit()` requires the function to have a `request` parameter, but our stub implementation was missing it.

### Solution
- Added `request: Request` as the first parameter to all rate-limited endpoints
- Imported `Request` from FastAPI
- Maintains full API compatibility while fixing the deployment issue

### Changes
```python
# Before
async def export_menu_disabled(
    restaurant_id: str,
    ...
):

# After  
async def export_menu_disabled(
    request: Request,  # Added this parameter
    restaurant_id: str,
    ...
):
```

### Testing
- Endpoints now accept the required `request` parameter
- Rate limiting works correctly
- Authentication and other parameters remain intact

**This fix is required for the backend to start in production.**