### PR TITLE
fix: remove OrderItem import from dashboard to fix deployment

### DIFF
--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -10,7 +10,7 @@ from sqlalchemy import and_, func, case
 from collections import defaultdict
 import json
 
-from app.core.database import get_db, Restaurant, Order, OrderItem, Product, User, Employee, Customer, Inventory
+from app.core.database import get_db, Restaurant, Order, Product, User, Employee, Customer, Inventory
 from app.core.auth import get_current_user
 from app.core.redis_client import get_redis, RedisClient
 from app.core.responses import APIResponseHelper
@@ -80,23 +80,25 @@ async def get_dashboard_metrics(
     total_orders = len(orders)
     avg_order_value = total_revenue / total_orders if total_orders > 0 else 0
     
-    # Get top products
-    top_products_query = db.query(
-        Product.name,
-        func.sum(OrderItem.quantity).label('total_quantity'),
-        func.sum(OrderItem.subtotal).label('total_revenue')
-    ).join(
-        OrderItem, Product.id == OrderItem.product_id
-    ).join(
-        Order, OrderItem.order_id == Order.id
-    ).filter(
-        Order.restaurant_id == restaurant_id,
-        Order.created_at >= start_date,
-        Order.created_at <= end_date,
-        Order.status.in_(['completed', 'paid'])
-    ).group_by(Product.id, Product.name).order_by(
-        func.sum(OrderItem.quantity).desc()
-    ).limit(5).all()
+    # Get top products - TEMPORARILY DISABLED (OrderItem model not available)
+    # TODO: Implement when OrderItem model is added to database
+    top_products_query = []
+    # top_products_query = db.query(
+    #     Product.name,
+    #     func.sum(OrderItem.quantity).label('total_quantity'),
+    #     func.sum(OrderItem.subtotal).label('total_revenue')
+    # ).join(
+    #     OrderItem, Product.id == OrderItem.product_id
+    # ).join(
+    #     Order, OrderItem.order_id == Order.id
+    # ).filter(
+    #     Order.restaurant_id == restaurant_id,
+    #     Order.created_at >= start_date,
+    #     Order.created_at <= end_date,
+    #     Order.status.in_(['completed', 'paid'])
+    # ).group_by(Product.id, Product.name).order_by(
+    #     func.sum(OrderItem.quantity).desc()
+    # ).limit(5).all()
     
     # Get staff metrics
     active_staff = db.query(func.count(Employee.id)).filter(


### PR DESCRIPTION
## 🚨 Critical Fix for Backend Deployment

### Problem
Backend deployment is failing with:
```
ImportError: cannot import name 'OrderItem' from 'app.core.database'
```

### Root Cause
The dashboard.py endpoint is trying to import `OrderItem` from the database module, but this model doesn't exist. The `OrderItem` is only defined as a Pydantic schema in orders.py, not as a database model.

### Solution
1. Removed `OrderItem` from the import statement
2. Temporarily disabled the top products query that depends on OrderItem
3. Returns empty array for top products until OrderItem model is properly implemented

### Changes
```python
# Before
from app.core.database import get_db, Restaurant, Order, OrderItem, Product, User, Employee, Customer, Inventory

# After
from app.core.database import get_db, Restaurant, Order, Product, User, Employee, Customer, Inventory

# Disabled query
top_products_query = []  # Temporarily returns empty array
```

### Impact
- Dashboard endpoint will work but won't show top selling products
- All other metrics (revenue, orders, customers, staff, inventory) work correctly
- Added TODO comment to implement when OrderItem model is added

**This fix is required for the backend to start in production.**