### PR TITLE
Fix POS menu loading and authentication issues

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/services/DatabaseService.ts
+++ b/CashApp-iOS/CashAppPOS/src/services/DatabaseService.ts
@@ -105,7 +105,17 @@ class DatabaseService {
   }
 
   private async getAuthToken(): Promise<string | null> {
-    // First try to get fresh token from Supabase
+    // Import AUTH_CONFIG to check if we're using mock auth
+    const { AUTH_CONFIG } = await import('../config/auth.config');
+    
+    // Check if using mock authentication
+    if (AUTH_CONFIG.USE_MOCK_AUTH) {
+      // Get token from AsyncStorage for mock auth
+      const storedToken = await AsyncStorage.getItem('auth_token');
+      return storedToken || this.authToken;
+    }
+    
+    // For real auth, get fresh token from Supabase
     const { data: { session } } = await supabase.auth.getSession();
     if (session) {
       return session.access_token;


### PR DESCRIPTION
## Summary
This PR fixes the critical issues preventing the POS screen from displaying menu items when the app loads.

## Issues Fixed
- ⏱️ **API Timeout**: Increased timeout from 3s to 10s to handle slower backend responses
- 🔐 **Authentication Errors**: Fixed token retrieval to properly check AUTH_CONFIG.USE_MOCK_AUTH
- 🍽️ **Empty Menu Screen**: Implemented proper fallback to local Chucho menu data
- 🔌 **WebSocket 403 Errors**: Fixed auth token handling in DatabaseService

## Changes Made
1. **POSScreen.tsx**: 
   - Increased API timeout to 10 seconds
   - Direct import of local menu data on API failure
   - Better error handling with proper fallback

2. **DatabaseService.ts**:
   - Added AUTH_CONFIG check in getAuthToken()
   - Properly handles both mock and real authentication modes
   - Ensures correct token source based on auth configuration

## Testing
- Built and deployed new iOS bundle
- Tested fallback to local menu data
- Verified auth token handling in both modes

## Result
The app now properly displays menu items even when:
- Backend API is slow or unavailable
- Authentication tokens are expired
- WebSocket connections fail

This ensures users always see content on the POS screen instead of an empty state.