### PR TITLE
Fix: PostgreSQL SSL connection for DigitalOcean managed database

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -21,16 +21,8 @@ from sqlalchemy.pool import QueuePool
 # Configure engine with proper connection pooling
 import os
 
-# Parse DATABASE_URL to handle SSL requirements
+# Use the original DATABASE_URL from settings
 database_url = settings.DATABASE_URL
-
-# Check if we need to add SSL parameters
-if "postgresql" in database_url and "sslmode" not in database_url:
-    # For DigitalOcean managed databases, we need SSL
-    if ":25060" in database_url or ":25061" in database_url:
-        # Add sslmode=require to the connection string
-        separator = "&" if "?" in database_url else "?"
-        database_url = f"{database_url}{separator}sslmode=require"
 
 connect_args = {}
 if "postgresql" in database_url:
@@ -40,11 +32,11 @@ if "postgresql" in database_url:
     }
     
     # For DigitalOcean managed databases, we need to provide the CA certificate
+    # The sslmode should already be in the connection string from environment variable
     if ":25060" in database_url or ":25061" in database_url:
         cert_path = os.path.join(os.path.dirname(__file__), "..", "..", "certs", "ca-certificate.crt")
         if os.path.exists(cert_path):
-            # Use the CA certificate for SSL verification
-            connect_args["sslmode"] = "require"
+            # Only provide the CA certificate path, not sslmode (already in URL)
             connect_args["sslrootcert"] = cert_path
             print(f"Using CA certificate for SSL: {cert_path}")
         else:

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -38,6 +38,17 @@ if "postgresql" in database_url:
         "connect_timeout": 10,  # PostgreSQL connection timeout
         "options": "-c statement_timeout=30000"  # 30 second statement timeout
     }
+    
+    # For DigitalOcean managed databases, we need to provide the CA certificate
+    if ":25060" in database_url or ":25061" in database_url:
+        cert_path = os.path.join(os.path.dirname(__file__), "..", "..", "certs", "ca-certificate.crt")
+        if os.path.exists(cert_path):
+            # Use the CA certificate for SSL verification
+            connect_args["sslmode"] = "require"
+            connect_args["sslrootcert"] = cert_path
+            print(f"Using CA certificate for SSL: {cert_path}")
+        else:
+            print(f"Warning: CA certificate not found at {cert_path}")
 
 engine = create_engine(
     database_url,

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -20,9 +20,20 @@ from sqlalchemy.pool import QueuePool
 
 # Configure engine with proper connection pooling
 import os
+import logging
 
-# Use the original DATABASE_URL from settings
+logger = logging.getLogger(__name__)
+
+# Parse DATABASE_URL to handle SSL requirements
 database_url = settings.DATABASE_URL
+
+# For DigitalOcean managed databases, ensure SSL mode is set
+if "postgresql" in database_url and (":25060" in database_url or ":25061" in database_url):
+    if "sslmode" not in database_url:
+        # Add sslmode=require to the connection string if not present
+        separator = "&" if "?" in database_url else "?"
+        database_url = f"{database_url}{separator}sslmode=require"
+        logger.info("Added sslmode=require to DigitalOcean database connection")
 
 connect_args = {}
 if "postgresql" in database_url:
@@ -31,16 +42,15 @@ if "postgresql" in database_url:
         "options": "-c statement_timeout=30000"  # 30 second statement timeout
     }
     
-    # For DigitalOcean managed databases, we need to provide the CA certificate
-    # The sslmode should already be in the connection string from environment variable
+    # For DigitalOcean managed databases, provide the CA certificate
     if ":25060" in database_url or ":25061" in database_url:
         cert_path = os.path.join(os.path.dirname(__file__), "..", "..", "certs", "ca-certificate.crt")
         if os.path.exists(cert_path):
-            # Only provide the CA certificate path, not sslmode (already in URL)
+            # Provide the CA certificate path for SSL verification
             connect_args["sslrootcert"] = cert_path
-            print(f"Using CA certificate for SSL: {cert_path}")
+            logger.info(f"Using CA certificate for SSL: {cert_path}")
         else:
-            print(f"Warning: CA certificate not found at {cert_path}")
+            logger.warning(f"CA certificate not found at {cert_path}")
 
 engine = create_engine(
     database_url,


### PR DESCRIPTION
## Summary
- Adds SSL mode configuration for DigitalOcean managed database connections
- Uses CA certificate for proper SSL verification
- Fixes authentication failures and API timeouts

## Problem
The DigitalOcean managed PostgreSQL database requires:
1. SSL connections with `sslmode=require`
2. CA certificate for SSL verification

Without these, the backend was experiencing:
- Database connection timeouts on port 25061
- Authentication failures ("Invalid token") 
- WebSocket 403 errors
- API request timeouts
- Menu data failing to load

## Solution
1. Automatically detect DigitalOcean database connections (ports 25060/25061)
2. Add `sslmode=require` to connection string if not present
3. Use the CA certificate from `backend/certs/ca-certificate.crt` for SSL verification
4. Pass certificate path via `sslrootcert` connection parameter

## Test Plan
- [ ] Deploy to DigitalOcean App Platform
- [ ] Verify health endpoint works
- [ ] Test authenticated API calls (should no longer timeout)
- [ ] Verify WebSocket connections succeed
- [ ] Confirm menu data loads properly in the mobile app
- [ ] Check that authentication tokens are validated correctly

🤖 Generated with Claude Code