### PR TITLE
Fix websocket arguments for order events

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/services/OrderService.ts
+++ b/CashApp-iOS/CashAppPOS/src/services/OrderService.ts
@@ -126,7 +126,7 @@ class OrderService {
       };
 
       // Emit WebSocket event for real-time updates
-      webSocketService.send('order_created', order);
+      webSocketService.send({ type: 'order_created', data: order });
 
       // Save to local storage for offline access
       await this.cacheOrder(order);
@@ -293,7 +293,7 @@ class OrderService {
       const updatedOrder = await response.json();
       
       // Emit WebSocket event
-      webSocketService.send('order_updated', updatedOrder);
+      webSocketService.send({ type: 'order_updated', data: updatedOrder });
 
       return updatedOrder;
     } catch (error) {


### PR DESCRIPTION
Correct `webSocketService.send` argument format to match `WebSocketMessage` interface, resolving runtime errors.