### PR TITLE
🚨 HOTFIX: Fix Redis syntax error preventing deployment

### DIFF
--- a/backend/app/core/redis_client.py
+++ b/backend/app/core/redis_client.py
@@ -190,7 +190,10 @@ class RedisClient:
             items = list(self._mock_storage[key].items())
             if withscores:
                 return items[:end+1] if end != -1 else items
-            return [k for k, v in items[:end+1] if end != -1 else items]
+            else:
+                # Extract just the keys from the items
+                selected_items = items[:end+1] if end != -1 else items
+                return [k for k, v in selected_items]
         try:
             return await self.redis.zrange(key, start, end, withscores=withscores)
         except Exception as e:


### PR DESCRIPTION
## 🚨 Critical Production Fix

This PR fixes a **syntax error** that is preventing the backend from starting in production.

## Problem
The deployment is failing with:
```
SyntaxError: invalid syntax
  File "/workspace/backend/app/core/redis_client.py", line 193
    return [k for k, v in items[:end+1] if end \!= -1 else items]
```

## Root Cause
Invalid ternary operator usage inside a list comprehension. Python doesn't allow this syntax:
```python
[k for k, v in items[:end+1] if end \!= -1 else items]  # ❌ INVALID
```

## Solution
Properly structured the conditional logic:
```python
if withscores:
    return items[:end+1] if end \!= -1 else items
else:
    selected_items = items[:end+1] if end \!= -1 else items
    return [k for k, v in selected_items]  # ✅ VALID
```

## Impact
- **Severity**: CRITICAL - Backend cannot start
- **Affected**: All deployments after PR #287 was merged
- **Fix**: Immediate - syntax correction only

## Testing
- Syntax is now valid Python
- Mock Redis zrange method will work correctly
- No functional changes, only syntax fix

**This needs to be merged immediately to restore service.**