### PR TITLE
fix(websocket): prevent premature connection attempts and improve timing

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts
+++ b/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts
@@ -124,9 +124,9 @@ export const useWebSocket = (options: UseWebSocketOptions = {}) => {
     };
   }, []);
   
-  // Auto-connect on mount if enabled
+  // Auto-connect on mount if explicitly enabled
   useEffect(() => {
-    if (options.autoConnect !== false && user?.restaurant_id && !state.connected && !state.connecting) {
+    if (options.autoConnect === true && user?.restaurant_id && !state.connected && !state.connecting) {
       connect();
     }
     
@@ -153,7 +153,7 @@ export const useWebSocket = (options: UseWebSocketOptions = {}) => {
 // Export specific event hooks for common use cases
 
 export const useOrderUpdates = (onOrderUpdate: (data: any) => void) => {
-  const { subscribe } = useWebSocket();
+  const { subscribe } = useWebSocket({ autoConnect: false });
   
   useEffect(() => {
     const unsubscribeCreated = subscribe(WebSocketEventType.ORDER_CREATED, onOrderUpdate);
@@ -169,7 +169,7 @@ export const useOrderUpdates = (onOrderUpdate: (data: any) => void) => {
 };
 
 export const useInventoryUpdates = (onInventoryUpdate: (data: any) => void) => {
-  const { subscribe } = useWebSocket();
+  const { subscribe } = useWebSocket({ autoConnect: false });
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.INVENTORY_UPDATED, onInventoryUpdate);
@@ -178,7 +178,7 @@ export const useInventoryUpdates = (onInventoryUpdate: (data: any) => void) => {
 };
 
 export const useMenuUpdates = (onMenuUpdate: (data: any) => void) => {
-  const { subscribe } = useWebSocket();
+  const { subscribe } = useWebSocket({ autoConnect: false });
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.MENU_UPDATED, onMenuUpdate);
@@ -187,7 +187,7 @@ export const useMenuUpdates = (onMenuUpdate: (data: any) => void) => {
 };
 
 export const useSystemNotifications = (onNotification: (data: any) => void) => {
-  const { subscribe } = useWebSocket();
+  const { subscribe } = useWebSocket({ autoConnect: false });
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.SYSTEM_NOTIFICATION, onNotification);

--- a/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts
+++ b/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts
@@ -151,9 +151,11 @@ export const useWebSocket = (options: UseWebSocketOptions = {}) => {
 };
 
 // Export specific event hooks for common use cases
+// Note: These hooks do not auto-connect. You must ensure WebSocket is connected
+// by either using useWebSocket with autoConnect: true or manually calling connect()
 
 export const useOrderUpdates = (onOrderUpdate: (data: any) => void) => {
-  const { subscribe, connect, connected } = useWebSocket();
+  const { subscribe } = useWebSocket();
   
   useEffect(() => {
     const unsubscribeCreated = subscribe(WebSocketEventType.ORDER_CREATED, onOrderUpdate);
@@ -166,67 +168,31 @@ export const useOrderUpdates = (onOrderUpdate: (data: any) => void) => {
       unsubscribeStatus();
     };
   }, [subscribe, onOrderUpdate]);
-  
-  // Ensure connection when using this hook
-  useEffect(() => {
-    if (!connected) {
-      connect();
-    }
-  }, [connected, connect]);
-  
-  return { connected, connect };
 };
 
 export const useInventoryUpdates = (onInventoryUpdate: (data: any) => void) => {
-  const { subscribe, connect, connected } = useWebSocket();
+  const { subscribe } = useWebSocket();
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.INVENTORY_UPDATED, onInventoryUpdate);
     return unsubscribe;
   }, [subscribe, onInventoryUpdate]);
-  
-  // Ensure connection when using this hook
-  useEffect(() => {
-    if (!connected) {
-      connect();
-    }
-  }, [connected, connect]);
-  
-  return { connected, connect };
 };
 
 export const useMenuUpdates = (onMenuUpdate: (data: any) => void) => {
-  const { subscribe, connect, connected } = useWebSocket();
+  const { subscribe } = useWebSocket();
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.MENU_UPDATED, onMenuUpdate);
     return unsubscribe;
   }, [subscribe, onMenuUpdate]);
-  
-  // Ensure connection when using this hook
-  useEffect(() => {
-    if (!connected) {
-      connect();
-    }
-  }, [connected, connect]);
-  
-  return { connected, connect };
 };
 
 export const useSystemNotifications = (onNotification: (data: any) => void) => {
-  const { subscribe, connect, connected } = useWebSocket();
+  const { subscribe } = useWebSocket();
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.SYSTEM_NOTIFICATION, onNotification);
     return unsubscribe;
   }, [subscribe, onNotification]);
-  
-  // Ensure connection when using this hook
-  useEffect(() => {
-    if (!connected) {
-      connect();
-    }
-  }, [connected, connect]);
-  
-  return { connected, connect };
 };

--- a/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts
+++ b/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts
@@ -153,7 +153,7 @@ export const useWebSocket = (options: UseWebSocketOptions = {}) => {
 // Export specific event hooks for common use cases
 
 export const useOrderUpdates = (onOrderUpdate: (data: any) => void) => {
-  const { subscribe } = useWebSocket({ autoConnect: false });
+  const { subscribe, connect, connected } = useWebSocket();
   
   useEffect(() => {
     const unsubscribeCreated = subscribe(WebSocketEventType.ORDER_CREATED, onOrderUpdate);
@@ -166,31 +166,67 @@ export const useOrderUpdates = (onOrderUpdate: (data: any) => void) => {
       unsubscribeStatus();
     };
   }, [subscribe, onOrderUpdate]);
+  
+  // Ensure connection when using this hook
+  useEffect(() => {
+    if (!connected) {
+      connect();
+    }
+  }, [connected, connect]);
+  
+  return { connected, connect };
 };
 
 export const useInventoryUpdates = (onInventoryUpdate: (data: any) => void) => {
-  const { subscribe } = useWebSocket({ autoConnect: false });
+  const { subscribe, connect, connected } = useWebSocket();
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.INVENTORY_UPDATED, onInventoryUpdate);
     return unsubscribe;
   }, [subscribe, onInventoryUpdate]);
+  
+  // Ensure connection when using this hook
+  useEffect(() => {
+    if (!connected) {
+      connect();
+    }
+  }, [connected, connect]);
+  
+  return { connected, connect };
 };
 
 export const useMenuUpdates = (onMenuUpdate: (data: any) => void) => {
-  const { subscribe } = useWebSocket({ autoConnect: false });
+  const { subscribe, connect, connected } = useWebSocket();
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.MENU_UPDATED, onMenuUpdate);
     return unsubscribe;
   }, [subscribe, onMenuUpdate]);
+  
+  // Ensure connection when using this hook
+  useEffect(() => {
+    if (!connected) {
+      connect();
+    }
+  }, [connected, connect]);
+  
+  return { connected, connect };
 };
 
 export const useSystemNotifications = (onNotification: (data: any) => void) => {
-  const { subscribe } = useWebSocket({ autoConnect: false });
+  const { subscribe, connect, connected } = useWebSocket();
   
   useEffect(() => {
     const unsubscribe = subscribe(WebSocketEventType.SYSTEM_NOTIFICATION, onNotification);
     return unsubscribe;
   }, [subscribe, onNotification]);
+  
+  // Ensure connection when using this hook
+  useEffect(() => {
+    if (!connected) {
+      connect();
+    }
+  }, [connected, connect]);
+  
+  return { connected, connect };
 };

--- a/CashApp-iOS/CashAppPOS/src/screens/main/HomeHubScreen.tsx
+++ b/CashApp-iOS/CashAppPOS/src/screens/main/HomeHubScreen.tsx
@@ -39,7 +39,7 @@ const HomeHubScreen: React.FC = () => {
   const styles = useThemedStyles(createStyles);
   const { user, signOut } = useAuth();
   const { cartItemCount } = useAppStore();
-  const { connected: wsConnected } = useWebSocket({ autoConnect: true });
+  const { connected: wsConnected } = useWebSocket({ autoConnect: false });
 
   // Hub icons configuration with role-based visibility
   const hubIcons: HubIcon[] = [

--- a/PR_295_CRITICAL_FIXES_COMPLETE.md
+++ b/PR_295_CRITICAL_FIXES_COMPLETE.md
@@ -1,0 +1,87 @@
+# PR #295: Critical Authentication, WebSocket & Redis Fixes - COMPLETE
+
+## 🚨 Critical Issues Resolved
+
+### 1. ✅ Redis/Valkey Connection (FIXED)
+**Problem**: DigitalOcean Valkey connection timing out, falling back to mock storage
+**Solution**: 
+- Added user's IP to trusted sources in DigitalOcean
+- Fixed TypedDict import for Python < 3.12 compatibility
+- Connection now working successfully
+
+### 2. ✅ Database Schema Mismatch (FIXED)
+**Problem**: Authentication failing with 500 error due to missing `floor_plan_layout` column
+**Solution**:
+- Modified auth.py to explicitly select columns (temporary workaround)
+- Created `run_migrations.py` script to apply pending migrations
+- Fixed stale cache issue when updating subscription data
+
+### 3. ✅ WebSocket Premature Connection (FIXED)
+**Problem**: WebSocket attempting to connect before authentication completed
+**Solutions**:
+- Fixed EnhancedWebSocketService to check auth before network reconnection
+- Disabled auto-connect in HomeHubScreen
+- Changed useWebSocket hook to require explicit `autoConnect: true`
+- Updated all specialized hooks to not auto-connect by default
+
+### 4. ✅ Additional Bug Fixes
+- Fixed unreliable rowcount usage in migration script (use fetchone instead)
+- Fixed stale cache in auth endpoint after subscription updates
+
+## Files Modified
+
+### Backend
+- `/backend/app/api/v1/endpoints/auth.py` - Column selection workaround & cache fix
+- `/backend/app/schemas/fee_schemas.py` - TypedDict import fix
+- `/backend/run_migrations.py` - Migration runner with proper row checking
+
+### Frontend
+- `/CashApp-iOS/CashAppPOS/src/services/websocket/EnhancedWebSocketService.ts` - Auth check before reconnect
+- `/CashApp-iOS/CashAppPOS/src/screens/main/HomeHubScreen.tsx` - Disabled auto-connect
+- `/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts` - Changed default behavior
+
+## Testing Checklist
+
+### Backend Testing
+```bash
+cd backend
+# Test Redis connection
+python test_valkey_connection.py
+
+# Run migrations
+python run_migrations.py
+
+# Start server and verify no errors
+uvicorn app.main:app --reload
+```
+
+### Frontend Testing
+1. Build new iOS bundle:
+```bash
+cd CashApp-iOS/CashAppPOS
+npx metro build index.js --platform ios --dev false --out ios/main.jsbundle
+mv ios/main.jsbundle.js ios/main.jsbundle
+cp ios/main.jsbundle ios/CashAppPOS/main.jsbundle
+```
+
+2. Run iOS app and verify:
+   - ✅ No WebSocket connection attempts before login
+   - ✅ Successful authentication without 500 errors
+   - ✅ WebSocket connects properly when needed
+   - ✅ Redis caching working (check server logs)
+
+## Deployment Steps
+1. Merge this PR to trigger deployment
+2. Run database migrations on production:
+   ```bash
+   python run_migrations.py
+   ```
+3. Verify Redis connection in production logs
+4. Monitor for any authentication errors
+
+## Impact
+These fixes resolve the critical issues preventing users from signing in and ensure stable WebSocket/Redis connections. The app should now:
+- Successfully authenticate users without errors
+- Not attempt WebSocket connections prematurely
+- Use Redis caching properly instead of falling back to mock storage
+- Handle subscription data updates correctly

--- a/WEBSOCKET_TIMING_FIX.md
+++ b/WEBSOCKET_TIMING_FIX.md
@@ -1,0 +1,36 @@
+# WebSocket Connection Timing Fix
+
+## Problem
+WebSocket was attempting to connect immediately after user authentication, before the auth token was fully stored, causing connection failures with the error "WebSocket connection failed: Error Domain=NSPOSIXErrorDomain Code=61 'Connection refused'".
+
+## Root Cause
+1. `HomeHubScreen` was using `useWebSocket({ autoConnect: true })`
+2. After authentication, the app immediately navigates to HomeHubScreen
+3. The WebSocket would try to connect before the auth token was fully available
+4. The `useWebSocket` hook defaulted to auto-connecting when no option was specified
+
+## Solution
+1. Changed `HomeHubScreen` to use `useWebSocket({ autoConnect: false })`
+2. Updated `useWebSocket` hook to only auto-connect when explicitly set to `true`
+3. Updated all specialized hooks to not auto-connect by default:
+   - `useOrderUpdates`
+   - `useInventoryUpdates`
+   - `useMenuUpdates`
+   - `useSystemNotifications`
+
+## Files Modified
+- `/CashApp-iOS/CashAppPOS/src/screens/main/HomeHubScreen.tsx` - Disabled auto-connect
+- `/CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts` - Changed default behavior and updated all hooks
+
+## Result
+WebSocket will no longer attempt to connect immediately after authentication. Components that need real-time updates should explicitly connect when needed, giving the authentication process time to complete and store tokens properly.
+
+## How to Connect WebSocket When Needed
+```typescript
+// Option 1: Explicit auto-connect
+const { connected } = useWebSocket({ autoConnect: true });
+
+// Option 2: Manual connection
+const { connect, connected } = useWebSocket();
+// Then call connect() when ready
+```


### PR DESCRIPTION
## 🚨 Critical WebSocket Timing Fix

After merging PR #295, you reported that WebSocket connections were still failing. This PR fixes the root cause.

## Problem
WebSocket was attempting to connect immediately when `HomeHubScreen` loaded, before authentication tokens were fully stored, causing "Connection refused" errors.

## Solution
1. **Disabled auto-connect in HomeHubScreen** - Changed from `useWebSocket({ autoConnect: true })` to `{ autoConnect: false }`
2. **Changed useWebSocket default behavior** - Now requires explicit `autoConnect: true` to connect on mount
3. **Updated all WebSocket hooks** - useOrderUpdates, useInventoryUpdates, etc. now default to not auto-connecting

## Files Changed
- `CashApp-iOS/CashAppPOS/src/screens/main/HomeHubScreen.tsx` - Disabled auto-connect
- `CashApp-iOS/CashAppPOS/src/hooks/useWebSocket.ts` - Changed default behavior

## Testing
- WebSocket will no longer attempt to connect immediately after login
- Components must explicitly enable auto-connect when needed
- This gives authentication time to complete properly

## Additional Fixes Included
- Fixed stale cache issue in auth endpoint (re-queries after subscription update)
- Fixed unreliable rowcount usage in migrations (now uses fetchone())

Deploy this to fix the WebSocket connection timing issues reported in Xcode logs.