### PR TITLE
🚨 HOTFIX: Remove invalid SSL parameter causing Redis connection error

### DIFF
--- a/backend/app/core/redis_client.py
+++ b/backend/app/core/redis_client.py
@@ -58,16 +58,14 @@ class RedisClient:
                 
                 # If using rediss:// (SSL), ensure SSL is properly configured for DigitalOcean Valkey
                 if settings.REDIS_URL.startswith('rediss://'):
-                    import ssl
-                    # Create SSL context that works with DigitalOcean Valkey
-                    ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-                    ssl_context.check_hostname = False
-                    ssl_context.verify_mode = ssl.CERT_NONE
-                    
+                    # For redis-py library, SSL parameters are handled differently
+                    # ConnectionPool.from_url doesn't accept 'ssl' parameter
                     connection_kwargs.update({
-                        'ssl': ssl_context,
-                        'ssl_cert_reqs': None,
+                        'ssl_cert_reqs': 'none',  # String 'none', not None
                         'ssl_check_hostname': False,
+                        'ssl_ca_certs': None,
+                        'ssl_certfile': None,
+                        'ssl_keyfile': None,
                     })
                 
                 self.pool = ConnectionPool.from_url(


### PR DESCRIPTION
## Critical Redis Connection Fix

This PR fixes the Redis connection error that's preventing the application from starting:
```
❌ Failed to connect to Redis: AbstractConnection.__init__() got an unexpected keyword argument 'ssl'
```

## Problem
PR #297 introduced an `ssl` parameter that the redis-py library doesn't accept in `ConnectionPool.from_url()`, causing immediate connection failure on startup.

## Solution
- Removed the invalid `ssl` parameter
- Use the correct SSL parameters that redis-py accepts:
  - `ssl_cert_reqs='none'` (must be string, not None)
  - `ssl_check_hostname=False`
  - Other SSL-related parameters

## Testing
After this fix, Redis should connect without the "unexpected keyword argument" error.

## Urgency
This is a **CRITICAL HOTFIX** - the application cannot start without this fix as Redis initialization fails immediately.

## Deployment
Needs immediate deployment to restore Redis functionality in production.