### PR TITLE
fix: Remove floor_plan_layout field to resolve database query failures

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -144,8 +144,8 @@ class Restaurant(Base):
         "applePay": {"enabled": True, "feePercentage": 2.9},
         "giftCard": {"enabled": True, "requiresAuth": True}
     })
-    floor_plan_layout = Column(JSONB)  # New field for layout storage
-    # Subscription fields for Supabase integration
+    # NOTE: floor_plan_layout removed - not implemented in mobile app
+    # Subscription fields for displaying plan info (managed via web platform)
     subscription_plan = Column(String(50), default='alpha')  # alpha, beta, omega
     subscription_status = Column(String(50), default='trial')  # trial, active, cancelled, expired
     subscription_started_at = Column(DateTime(timezone=True), nullable=True)


### PR DESCRIPTION
## 🚨 Critical Fix: Database Query Failures

This PR fixes the critical issue causing WebSocket connection failures and API timeouts by removing the `floor_plan_layout` field from the Restaurant model.

## 🔍 Root Cause Analysis

### The Problem
The backend Restaurant model included a `floor_plan_layout` JSONB field that:
1. **Doesn't exist in the production database**
2. **Isn't implemented in the mobile app**
3. **Causes ALL restaurant queries to fail** with: `column restaurants.floor_plan_layout does not exist`

### The Cascade Effect
```
Missing column → Restaurant queries fail → No restaurant data → WebSocket fails → API timeouts
```

## ✅ The Solution

This PR removes only the `floor_plan_layout` field while keeping the subscription fields because:

1. **Floor Plan Layout** - Not implemented, not needed, causing failures
2. **Subscription Fields** - Must be kept to:
   - Display current plan (Alpha/Beta/Omega) in the app
   - Enable upgrade button that links to web platform
   - Support authentication flow that uses these fields

## 📊 Changes Made

```python
# Removed:
floor_plan_layout = Column(JSONB)  # This was causing the failures

# Kept:
subscription_plan = Column(String(50), default='alpha')
subscription_status = Column(String(50), default='trial')
subscription_started_at = Column(DateTime(timezone=True), nullable=True)
subscription_expires_at = Column(DateTime(timezone=True), nullable=True)
```

## 🚀 Expected Results

### Before This Fix
- ❌ `column restaurants.floor_plan_layout does not exist` errors
- ❌ WebSocket fails with "No restaurant associated with user"
- ❌ API requests timeout after 10 seconds
- ❌ Menu loading fails and falls back to cached data

### After This Fix
- ✅ Restaurant queries succeed
- ✅ WebSocket connects properly
- ✅ API responds quickly
- ✅ All features work as expected

## 📋 Additional Steps Required

After merging this PR, you'll need to add the subscription columns to the database:

```sql
ALTER TABLE restaurants 
ADD COLUMN IF NOT EXISTS subscription_plan VARCHAR(50) DEFAULT 'alpha',
ADD COLUMN IF NOT EXISTS subscription_status VARCHAR(50) DEFAULT 'trial',
ADD COLUMN IF NOT EXISTS subscription_started_at TIMESTAMPTZ,
ADD COLUMN IF NOT EXISTS subscription_expires_at TIMESTAMPTZ;
```

## 🧪 Testing

1. Deploy this change
2. Check backend logs - should see successful restaurant queries
3. Test mobile app - WebSocket should connect
4. Verify subscription plan displays in app settings

## 📌 Important Notes

- This is a **critical production fix**
- No data migration needed - we're removing a field that never existed in the database
- Subscription management remains on the web platform as designed
- Mobile app will display plan info (read-only) with upgrade link

## 🔗 Related Issues

- Fixes WebSocket connection failures
- Fixes API timeout issues
- Fixes "No restaurant associated with user" errors
- Enables proper subscription plan display in mobile app