### PR TITLE
Hotfix: DATABASE_URL validation to fix deployment error

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -27,6 +27,23 @@ logger = logging.getLogger(__name__)
 # Parse DATABASE_URL to handle SSL requirements
 database_url = settings.DATABASE_URL
 
+# Validate DATABASE_URL is a PostgreSQL URL
+if not database_url:
+    raise ValueError("DATABASE_URL environment variable is not set")
+
+if database_url.startswith(("redis://", "rediss://")):
+    raise ValueError(
+        "DATABASE_URL is set to a Redis URL instead of PostgreSQL. "
+        "Please check your environment variables. "
+        "DATABASE_URL should be postgresql://... and REDIS_URL should be redis(s)://..."
+    )
+
+if not database_url.startswith(("postgresql://", "postgres://")):
+    raise ValueError(
+        f"DATABASE_URL must be a PostgreSQL URL (postgresql:// or postgres://), "
+        f"but got: {database_url.split('://')[0]}://"
+    )
+
 # For DigitalOcean managed databases, ensure SSL mode is set
 if "postgresql" in database_url and ("digitalocean.com" in database_url or ":25060" in database_url or ":25061" in database_url):
     # Port 25061 is for connection pooling (PgBouncer), 25060 is direct

--- a/backend/app/core/env_check.py
+++ b/backend/app/core/env_check.py
@@ -1,0 +1,55 @@
+"""
+Environment variable validation and debugging
+"""
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+def check_environment_variables():
+    """Check and log environment variables for debugging deployment issues"""
+    
+    # Check DATABASE_URL
+    database_url = os.getenv("DATABASE_URL", "")
+    if database_url:
+        # Log the protocol only for security
+        protocol = database_url.split("://")[0] if "://" in database_url else "unknown"
+        logger.info(f"DATABASE_URL protocol: {protocol}")
+        
+        if protocol.startswith("redis"):
+            logger.error("🚨 DATABASE_URL is set to a Redis URL instead of PostgreSQL!")
+            logger.error("Please check your DigitalOcean environment variables")
+            logger.error("DATABASE_URL should be postgresql://...")
+            logger.error("REDIS_URL should be redis(s)://...")
+    else:
+        logger.warning("DATABASE_URL is not set")
+    
+    # Check REDIS_URL
+    redis_url = os.getenv("REDIS_URL", "")
+    if redis_url:
+        protocol = redis_url.split("://")[0] if "://" in redis_url else "unknown"
+        logger.info(f"REDIS_URL protocol: {protocol}")
+        
+        if protocol.startswith("postgres"):
+            logger.error("🚨 REDIS_URL is set to a PostgreSQL URL instead of Redis!")
+            logger.error("Please check your DigitalOcean environment variables")
+    else:
+        logger.info("REDIS_URL is not set (will use in-memory fallback)")
+    
+    # Check for common mixups
+    if database_url and redis_url:
+        if database_url == redis_url:
+            logger.error("🚨 DATABASE_URL and REDIS_URL are set to the same value!")
+            logger.error("These must be different services")
+    
+    # Log other important environment variables
+    logger.info(f"ENVIRONMENT: {os.getenv('ENVIRONMENT', 'not set')}")
+    logger.info(f"APP_ENV: {os.getenv('APP_ENV', 'not set')}")
+    logger.info(f"PORT: {os.getenv('PORT', 'not set')}")
+    
+    # Check Supabase configuration
+    supabase_url = os.getenv("SUPABASE_URL", "")
+    if supabase_url:
+        logger.info("SUPABASE_URL is configured")
+    else:
+        logger.warning("SUPABASE_URL is not set")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ import logging
 from contextlib import asynccontextmanager
 
 from app.core.config import settings
+from app.core.env_check import check_environment_variables
 from app.core.database import init_db, get_db, User
 from app.api.v1.api import api_router
 from app.api.mobile.endpoints import router as mobile_router
@@ -57,6 +58,9 @@ security = HTTPBearer()
 async def lifespan(app: FastAPI):
     """Initialize application on startup"""
     logger.info(f"🚀 Fynlo POS Backend starting in {settings.ENVIRONMENT} mode...")
+    
+    # Check environment variables for common issues
+    check_environment_variables()
     
     # Initialize all services
     from app.core.startup_handler import startup_handler, shutdown_handler


### PR DESCRIPTION
## 🚨 Critical Deployment Fix

The deployment is failing with:
```
sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:rediss
```

## 🔧 Root Cause

The DATABASE_URL environment variable was accidentally set to a Redis URL (`rediss://`) instead of PostgreSQL, causing SQLAlchemy to try loading a Redis dialect for the database connection.

## 🛠️ Solution

1. **Added DATABASE_URL validation** in `database.py`:
   - Checks that DATABASE_URL starts with `postgresql://` or `postgres://`
   - Provides clear error if Redis URL is detected
   - Prevents app from starting with wrong configuration

2. **Created environment check module** (`env_check.py`):
   - Logs environment variable protocols on startup
   - Detects common mixups (DATABASE_URL ↔ REDIS_URL)
   - Helps debug deployment issues

3. **Integrated checks into startup** in `main.py`:
   - Runs environment checks before initializing services
   - Provides immediate feedback on configuration issues

## 🔍 What to Do

After merging this:
1. Check your DigitalOcean environment variables
2. Ensure DATABASE_URL points to PostgreSQL
3. Ensure REDIS_URL points to Redis/Valkey
4. Redeploy the application

## Example Correct Configuration

```
DATABASE_URL=postgresql://user:pass@host:port/dbname
REDIS_URL=rediss://user:pass@host:port/0
```

This is a critical fix to get the deployment working again\!