### PR TITLE
fix: remove old menu data and ensure only Chucho menu exists

### DIFF
--- a/backend/fix_menu.sh
+++ b/backend/fix_menu.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Fix menu by running the Chucho menu seed script which now clears all old data first
+
+echo "🌮 Fixing menu - Loading ONLY Chucho menu"
+echo "======================================="
+
+# Run the updated seed script
+python seed_chucho_menu.py
+
+echo ""
+echo "✅ Menu fix complete! Only Chucho menu should now be visible."

--- a/backend/seed_chucho_menu.py
+++ b/backend/seed_chucho_menu.py
@@ -127,6 +127,23 @@ def clear_existing_menu(db: Session, restaurant_id: str):
     db.commit()
     print("   ✅ Existing menu data cleared")
 
+def clear_all_menu_data(db: Session):
+    """Clear ALL menu data from all restaurants"""
+    print("🧹 Clearing ALL menu data from database...")
+    
+    from sqlalchemy import text
+    
+    # Delete all products
+    result = db.execute(text("DELETE FROM products"))
+    product_count = result.rowcount
+    
+    # Delete all categories
+    result = db.execute(text("DELETE FROM categories"))
+    category_count = result.rowcount
+    
+    db.commit()
+    print(f"   ✅ Deleted {product_count} products and {category_count} categories")
+
 def seed_categories(db: Session, restaurant_id: str) -> dict:
     """Seed menu categories and return mapping"""
     category_mapping = {}
@@ -219,8 +236,8 @@ def main():
         
         print(f"🏪 Found restaurant: {restaurant.name} (ID: {restaurant_id})")
         
-        # Clear existing menu data (optional - comment out if you want to preserve existing data)
-        # clear_existing_menu(db, restaurant_id)
+        # Clear ALL menu data from database to ensure only Chucho menu exists
+        clear_all_menu_data(db)
         
         # Seed categories
         category_mapping = seed_categories(db, restaurant_id)


### PR DESCRIPTION
## Summary
- Fixed the menu display issue by clearing ALL old menu data before loading Chucho menu
- Added `clear_all_menu_data()` function to completely remove all products and categories
- Created convenience script `fix_menu.sh` for easy execution

## Changes
- Modified `backend/seed_chucho_menu.py` to add menu clearing functionality
- Added `backend/fix_menu.sh` convenience script

## How to Fix the Menu
After merging, run on DigitalOcean:
```bash
cd backend
./fix_menu.sh
```

This will:
1. Clear ALL existing menu data from the database
2. Load ONLY the Chucho Mexican restaurant menu

## Note
This PR contains ONLY backend changes - no web platform or frontend modifications that could break Vercel deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)