### PR TITLE
Fix: Backend authentication service initialization

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -51,6 +51,8 @@ async def verify_supabase_user(
     client = supabase_admin or get_admin_client()
     if not client:
         logger.error("Supabase admin client not available")
+        logger.error(f"SUPABASE_URL set: {bool(settings.SUPABASE_URL)}")
+        logger.error(f"SUPABASE_SERVICE_ROLE_KEY set: {bool(settings.SUPABASE_SERVICE_ROLE_KEY)}")
         raise HTTPException(
             status_code=503,
             detail="Authentication service temporarily unavailable. Please check backend configuration."
@@ -225,6 +227,8 @@ async def register_restaurant(
     client = supabase_admin or get_admin_client()
     if not client:
         logger.error("Supabase admin client not available")
+        logger.error(f"SUPABASE_URL set: {bool(settings.SUPABASE_URL)}")
+        logger.error(f"SUPABASE_SERVICE_ROLE_KEY set: {bool(settings.SUPABASE_SERVICE_ROLE_KEY)}")
         raise HTTPException(
             status_code=503,
             detail="Authentication service temporarily unavailable. Please check backend configuration."

--- a/backend/app/core/supabase.py
+++ b/backend/app/core/supabase.py
@@ -20,6 +20,10 @@ def get_supabase_client() -> Client:
     supabase_url = settings.SUPABASE_URL or os.getenv("SUPABASE_URL")
     supabase_key = settings.SUPABASE_SERVICE_ROLE_KEY or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     
+    # Additional fallback check for secret key variable name
+    if not supabase_key:
+        supabase_key = os.getenv("supabase_secret_key")  # Check alternate env var name
+    
     if not supabase_url or not supabase_key:
         # Log which variables are missing for debugging
         missing = []
@@ -61,8 +65,6 @@ try:
     logger.info("✅ Supabase client initialized successfully at module load")
 except Exception as e:
     # Log the error but don't crash the app
-    logger.error(f"❌ Failed to initialize Supabase client at module load: {e}")
+    logger.warning(f"⚠️  Failed to initialize Supabase client at module load: {e}")
+    logger.warning("Supabase client will be initialized on first use")
     supabase_admin = None
-    
-    # Try to get it from the getter function as a fallback
-    supabase_admin = get_admin_client()


### PR DESCRIPTION
## Summary
- Fixed missing imports in main.py that were causing startup failures
- Replaced non-existent startup_handler and check_required_env_vars with proper initialization
- Added test endpoint to verify Supabase configuration status
- Improved Supabase client initialization with fallback for alternate environment variable names

## Changes
- Removed imports for non-existent functions
- Added proper database and Redis initialization in lifespan
- Added /api/v1/test/supabase-config endpoint for debugging
- Added fallback check for 'supabase_secret_key' environment variable
- Improved error logging to help diagnose configuration issues

## Testing
The test endpoint can be accessed at:
https://fynlopos-9eg2c.ondigitalocean.app/api/v1/test/supabase-config

This will help verify if Supabase environment variables are properly configured.

## Root Cause
The authentication error appears to be caused by the Supabase service role key environment variable possibly being named differently in the DigitalOcean app configuration.