### PR TITLE
Fix: Downgrade react-native-screens to resolve threading issue

### DIFF
--- a/CashApp-iOS/CashAppPOS/package-lock.json
+++ b/CashApp-iOS/CashAppPOS/package-lock.json
@@ -36,7 +36,7 @@
         "react-native-qrcode-svg": "^6.3.0",
         "react-native-reanimated": "3.5.4",
         "react-native-safe-area-context": "^4.8.0",
-        "react-native-screens": "3.27.0",
+        "react-native-screens": "3.20.0",
         "react-native-svg": "^15.2.0",
         "react-native-url-polyfill": "^2.0.0",
         "react-native-vector-icons": "^10.0.0",
@@ -11981,9 +11981,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.27.0.tgz",
-      "integrity": "sha512-FzSUygZ7yLQyhDJZsl7wU68LwRpVtVdqOPWribmEU3Tf26FohFGGcfJx1D8lf2V2Teb8tI+IaLnXCKbyh2xffA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.20.0.tgz",
+      "integrity": "sha512-joWUKWAVHxymP3mL9gYApFHAsbd9L6ZcmpoZa6Sl3W/82bvvNVMqcfP7MeNqVCg73qZ8yL4fW+J/syusHleUgg==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",

--- a/CashApp-iOS/CashAppPOS/package.json
+++ b/CashApp-iOS/CashAppPOS/package.json
@@ -47,7 +47,7 @@
     "react-native-qrcode-svg": "^6.3.0",
     "react-native-reanimated": "3.5.4",
     "react-native-safe-area-context": "^4.8.0",
-    "react-native-screens": "3.27.0",
+    "react-native-screens": "3.20.0",
     "react-native-svg": "^15.2.0",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-vector-icons": "^10.0.0",


### PR DESCRIPTION
## What
- Downgraded react-native-screens from 3.27.0 to 3.20.0
- This fixes the Xcode build error: `-[UIViewController invalidate] must be used from main thread only`

## Why
The error occurs because react-native-screens 3.27.0 has known threading issues with React Native 0.72.x. The library makes UIKit calls from background threads during React Native bridge initialization, which is not allowed in iOS.

Version 3.20.0 is known to be stable with React Native 0.72.x and doesn't have these threading issues.

## How
Simply downgraded the package version in package.json. This is a minimal change that resolves the threading issue without modifying any native code or build configurations.

## Testing
1. Run `npm install --legacy-peer-deps` to install the downgraded version
2. Run `cd ios && pod install` to update iOS dependencies
3. Clean build folder in Xcode: Product → Clean Build Folder
4. Build and run the app in Xcode
5. The threading error should no longer appear
6. Test sign-in functionality to ensure authentication works

## Notes
- This is a temporary fix until we can upgrade to React Native 0.73+ which has better compatibility with newer react-native-screens versions
- The previous attempt to fix this via Podfile modifications (PR #334) was causing build issues, so this simpler approach is preferred

## Related
- Follows PR #333 (Supabase auth error handling)
- Replaces PR #334 (previous threading fix attempt)