### PR TITLE
Fix: Complete UIViewController main thread safety

### DIFF
--- a/CashApp-iOS/CashAppPOS/patches/react-native+0.72.17.patch
+++ b/CashApp-iOS/CashAppPOS/patches/react-native+0.72.17.patch
@@ -1,31 +1,52 @@
 diff --git a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
-index 0e14093..1964907 100644
+index 0e14093..085c058 100644
 --- a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
 +++ b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
-@@ -1290,8 +1290,21 @@ - (void)invalidate
+@@ -1288,12 +1288,41 @@ - (void)invalidate
+ 
+       if ([moduleData.instance respondsToSelector:@selector(invalidate)]) {
          dispatch_group_enter(moduleInvalidation);
-         [self
-             dispatchBlock:^{
--              [(id<RCTInvalidating>)moduleData.instance invalidate];
--              dispatch_group_leave(moduleInvalidation);
-+              // Check if this is a UIViewController and needs main thread
-+              if ([moduleData.instance isKindOfClass:[UIViewController class]]) {
-+                if ([NSThread isMainThread]) {
+-        [self
+-            dispatchBlock:^{
++        
++        // ALL UIViewController operations must happen on main thread, including class checks
++        if ([NSThread isMainThread]) {
++          // We're on main thread, can safely check and invalidate
++          if ([moduleData.instance isKindOfClass:[UIViewController class]]) {
++            [(id<RCTInvalidating>)moduleData.instance invalidate];
++            dispatch_group_leave(moduleInvalidation);
++          } else {
++            // Non-UIViewController, dispatch to method queue
++            [self
++                dispatchBlock:^{
 +                  [(id<RCTInvalidating>)moduleData.instance invalidate];
 +                  dispatch_group_leave(moduleInvalidation);
-+                } else {
-+                  dispatch_async(dispatch_get_main_queue(), ^{
++                }
++                        queue:moduleData.methodQueue];
++          }
++        } else {
++          // Not on main thread, must dispatch to appropriate queue
++          // We need to check the class on main thread first
++          dispatch_async(dispatch_get_main_queue(), ^{
++            if ([moduleData.instance isKindOfClass:[UIViewController class]]) {
++              // UIViewController - invalidate on main thread
+               [(id<RCTInvalidating>)moduleData.instance invalidate];
+               dispatch_group_leave(moduleInvalidation);
++            } else {
++              // Non-UIViewController - dispatch to method queue
++              [self
++                  dispatchBlock:^{
 +                    [(id<RCTInvalidating>)moduleData.instance invalidate];
 +                    dispatch_group_leave(moduleInvalidation);
-+                  });
-+                }
-+              } else {
-+                [(id<RCTInvalidating>)moduleData.instance invalidate];
-+                dispatch_group_leave(moduleInvalidation);
-+              }
++                  }
++                          queue:moduleData.methodQueue];
              }
-                     queue:moduleData.methodQueue];
+-                    queue:moduleData.methodQueue];
++          });
++        }
        }
+       [moduleData invalidate];
+     }
 diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/rncore/ComponentDescriptors.h b/node_modules/react-native/ReactCommon/react/renderer/components/rncore/ComponentDescriptors.h
 new file mode 100644
 index 0000000..37b7d8d


### PR DESCRIPTION
## Problem
The UIViewController main thread error was still occurring because even the `isKindOfClass` check itself was happening on a background thread (Thread 7).

## Solution
- Ensure ALL UIViewController operations happen on main thread, including class checks
- If already on main thread, perform checks directly
- If on background thread, dispatch entire check to main thread first
- Then dispatch non-UIViewController modules to their method queues

## Error Fixed
```
-[UIViewController invalidate] must be used from main thread only
Thread 7
#0 in __26-[RCTCxxBridge invalidate]_block_invoke_2 at RCTCxxBridge.mm:1293
```

The error was happening at line 1293 which was the `isKindOfClass:[UIViewController class]` check itself.