### PR TITLE
Fix: Enable local backend testing and fix Pydantic compatibility

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/config/api.ts
+++ b/CashApp-iOS/CashAppPOS/src/config/api.ts
@@ -27,14 +27,14 @@ const isSimulator = __DEV__ && (
 const getBaseURL = () => {
   // PRODUCTION: Always try DigitalOcean backend first
   // During deployment phase, app will use mock data fallbacks if backend is unavailable
-  return PRODUCTION_API_URL;
+  // return PRODUCTION_API_URL;
   
-  // Development fallback (commented out for production readiness testing)
-  // if (isSimulator) {
-  //   return 'http://localhost:8000';
-  // } else {
-  //   return `http://${MAC_LAN_IP}:8000`;
-  // }
+  // Development fallback (temporarily enabled for local testing)
+  if (isSimulator) {
+    return 'http://localhost:8000';
+  } else {
+    return `http://${MAC_LAN_IP}:8000`;
+  }
 };
 
 // API Configuration

--- a/backend/app/schemas/fee_schemas.py
+++ b/backend/app/schemas/fee_schemas.py
@@ -1,4 +1,5 @@
-from typing import TypedDict, Optional, List
+from typing import Optional, List
+from typing_extensions import TypedDict
 from enum import Enum
 
 class PaymentMethodEnum(str, Enum):


### PR DESCRIPTION
## Summary
- Switch API configuration from production to localhost for development testing
- Fix Pydantic TypedDict import error that was preventing backend from starting
- Enable proper local development workflow for authentication debugging

## Changes

### API Configuration (src/config/api.ts)
- Temporarily enabled local backend URLs (localhost:8000) instead of production DigitalOcean URL
- This allows testing authentication flow with local backend
- Can be reverted once authentication issues are resolved

### Backend Fix (app/schemas/fee_schemas.py)
- Fixed Pydantic compatibility issue for Python < 3.12
- Changed from `typing.TypedDict` to `typing_extensions.TypedDict`
- This was preventing the backend from starting with error: "Please use typing_extensions.TypedDict instead"

## Testing
1. Start backend: `cd backend && uvicorn app.main:app --reload`
2. Backend should now start without Pydantic errors
3. iOS app should connect to localhost:8000 for API calls
4. Authentication flow can now be tested locally

## Context
This change was made to debug the "Authentication service error" that was occurring in the iOS app. The backend wasn't running due to the Pydantic error, and the app was pointing to production instead of localhost.