### PR TITLE
URGENT: Fix AttributeError in auth endpoint - remove invalid _headers access

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -68,7 +68,6 @@ async def verify_supabase_user(
         
         # Log Supabase client state
         logger.info(f"Supabase client URL: {client.supabase_url}")
-        logger.info(f"Supabase client headers: {list(client._headers.keys())}")
         
         user_response = client.auth.get_user(token)
         

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,7 +64,7 @@ async def lifespan(app: FastAPI):
         from app.core.redis_client import init_redis
         
         logger.info("Initializing database...")
-        init_db()
+        await init_db()
         
         logger.info("Initializing Redis...")
         await init_redis()


### PR DESCRIPTION
## 🚨 URGENT Production Fix

This PR fixes a critical error introduced in PR #341 that's causing authentication failures in production.

## Problem
After deploying PR #341, authentication started failing with:
```
AttributeError: 'SyncClient' object has no attribute '_headers'
```

## Root Cause
The debugging line `logger.info(f"Supabase client headers: {list(client._headers.keys())}")` was trying to access a private attribute `_headers` that doesn't exist on the Supabase SyncClient object.

## Solution
1. Removed the problematic debugging line that was accessing `client._headers`
2. Also fixed the `RuntimeWarning: coroutine 'init_db' was never awaited` warning

## Changes
- Removed line 71 in `auth.py` that was accessing non-existent `_headers` attribute
- Fixed `init_db()` call to properly await the coroutine in `main.py`

## Testing
This is a simple fix removing a debugging line that was causing the error. The auth endpoint will work correctly once this line is removed.

## Deployment Priority
**CRITICAL** - This needs to be deployed immediately as it's blocking all user authentication in production.