### PR TITLE
Fix: Handle users without restaurants for onboarding flow

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/services/websocket/EnhancedWebSocketService.ts
+++ b/CashApp-iOS/CashAppPOS/src/services/websocket/EnhancedWebSocketService.ts
@@ -74,14 +74,13 @@ export class EnhancedWebSocketService {
       }
       
       const user = JSON.parse(userInfo);
-      if (!user.restaurant_id) {
-        throw new Error('No restaurant associated with user');
-      }
+      // Allow users without restaurants to connect (for onboarding)
+      const restaurantId = user.restaurant_id || 'onboarding';
       
       // Build WebSocket URL (no token in URL for security)
       const wsProtocol = API_CONFIG.BASE_URL.startsWith('https') ? 'wss' : 'ws';
       const wsHost = API_CONFIG.BASE_URL.replace(/^https?:\/\//, '');
-      const wsUrl = `${wsProtocol}://${wsHost}/api/v1/websocket/ws/pos/${user.restaurant_id}`;
+      const wsUrl = `${wsProtocol}://${wsHost}/api/v1/websocket/ws/pos/${restaurantId}`;
       
       console.log('🔌 Connecting to WebSocket:', wsUrl);
       
@@ -128,11 +127,11 @@ export class EnhancedWebSocketService {
         data: {
           token: token,
           user_id: user.id,
-          restaurant_id: user.restaurant_id,
+          restaurant_id: user.restaurant_id || 'onboarding',
           client_type: 'mobile_pos',
           client_version: '1.0.0'
         },
-        restaurant_id: user.restaurant_id,
+        restaurant_id: user.restaurant_id || 'onboarding',
         timestamp: new Date().toISOString()
       };
       

--- a/backend/manual_fix_instructions.md
+++ b/backend/manual_fix_instructions.md
@@ -1,0 +1,70 @@
+# Manual Fix for "No restaurant associated with user" Error
+
+## Problem
+Your user account (arnaud@luciddirections.co.uk) doesn't have an associated restaurant, causing WebSocket connection failures.
+
+## Temporary Solution
+Until the debug endpoint is deployed, you can manually fix this by running SQL directly in the DigitalOcean database console:
+
+1. Go to DigitalOcean Dashboard
+2. Navigate to Databases → fynlo-pos-db
+3. Click on "Console" tab
+4. Run these SQL commands:
+
+```sql
+-- First, check if user exists and current restaurant_id
+SELECT id, email, restaurant_id, role 
+FROM users 
+WHERE email = 'arnaud@luciddirections.co.uk';
+
+-- Check if any restaurants exist
+SELECT id, name FROM restaurants LIMIT 1;
+
+-- If a restaurant exists, associate the user with it
+-- Replace <user_id> and <restaurant_id> with actual values from above queries
+UPDATE users 
+SET restaurant_id = '<restaurant_id>' 
+WHERE id = '<user_id>';
+```
+
+## Alternative: Create a test restaurant if none exists
+
+```sql
+-- Create a test restaurant
+INSERT INTO restaurants (
+    id, name, legal_name, address, city, postal_code,
+    country, phone, email, vat_number, vat_rate,
+    currency, timezone, is_active, created_at, updated_at
+) VALUES (
+    gen_random_uuid(), 
+    'Fynlo Test Restaurant',
+    'Fynlo Test Restaurant Ltd',
+    '123 Test Street',
+    'London',
+    'SW1A 1AA',
+    'UK',
+    '+44 20 1234 5678',
+    'test@fynlo.com',
+    'GB123456789',
+    20.0,
+    'GBP',
+    'Europe/London',
+    true,
+    NOW(),
+    NOW()
+) RETURNING id;
+
+-- Then update the user with the new restaurant_id
+UPDATE users 
+SET restaurant_id = '<new_restaurant_id>' 
+WHERE email = 'arnaud@luciddirections.co.uk';
+```
+
+## Expected Result
+After running these commands:
+1. WebSocket connections should work
+2. You'll be able to access all POS features
+3. Employee management will function properly
+
+## Note
+This is a temporary workaround. The proper solution is to implement restaurant association during the onboarding flow.


### PR DESCRIPTION
## Summary
- Fixed WebSocket connection issues for users without restaurants
- Aligned with proper flow: website signup → dashboard access → mobile app onboarding

## Changes
1. **Frontend WebSocket Service**:
   - Allow connections for users without restaurant_id
   - Use special 'onboarding' restaurant_id for pre-onboarding users
   - Continue to send authentication token

2. **Backend WebSocket Verification**:
   - Accept 'onboarding' as valid restaurant_id
   - Skip restaurant existence check for onboarding users
   - Allow any authenticated user to connect during onboarding

3. **Authentication Endpoint**:
   - Remove automatic restaurant creation on login
   - Add 'needs_onboarding' flag when user has no restaurant
   - Return minimal features for onboarding users

## Testing
1. Sign up new user on website
2. Login to mobile app with new user credentials
3. WebSocket should connect successfully
4. User can proceed with onboarding to create restaurant

## Why These Changes
As discussed, users sign up on the website first, get dashboard access, then use the mobile app for onboarding. The system must support users who haven't completed onboarding yet, allowing them to log in without a restaurant and complete the setup process in the app.

Fixes the "No restaurant associated with user" WebSocket errors that were preventing login for new users.