### PR TITLE
Fix: Comprehensive fix for TextInput ReferenceError in iOS bundle

### DIFF
--- a/CashApp-iOS/CashAppPOS/App.tsx
+++ b/CashApp-iOS/CashAppPOS/App.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { LogBox, View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { LogBox, View, Text, StyleSheet, ActivityIndicator, TextInput } from 'react-native';
 import 'react-native-gesture-handler';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AuthProvider } from './src/contexts/AuthContext';
@@ -17,6 +17,7 @@ import { supabase } from './src/lib/supabase';
 import { useAuthStore } from './src/store/useAuthStore';
 import { clearAuthStorage } from './src/utils/clearAuthStorage';
 import tokenManager from './src/utils/tokenManager';
+import { ensureComponentsLoaded } from './src/utils/componentRegistry';
 
 // Suppress specific warnings for development
 LogBox.ignoreLogs([
@@ -36,7 +37,11 @@ const App: React.FC = () => {
     const initializeApp = async () => {
       try {
         console.log('🚀 Fynlo POS App Starting...');
-        console.log('📱 BUNDLE VERSION: 2025-01-08-v9 - STABLE');
+        console.log('📱 BUNDLE VERSION: 2025-01-08-v10 - FIXED TextInput');
+        
+        // Ensure critical React Native components are not tree-shaken
+        // This prevents ReferenceError in production iOS builds
+        ensureComponentsLoaded();
         
         // Clear any stored authentication on app startup
         console.log('🧹 Clearing stored authentication...');

--- a/CashApp-iOS/CashAppPOS/src/screens/onboarding/ComprehensiveRestaurantOnboardingScreen.tsx
+++ b/CashApp-iOS/CashAppPOS/src/screens/onboarding/ComprehensiveRestaurantOnboardingScreen.tsx
@@ -420,7 +420,7 @@ const ComprehensiveRestaurantOnboardingScreen: React.FC = () => {
         [
           {
             text: 'Start Using POS',
-            onPress: () => navigation.navigate('MainPOS' as never),
+            onPress: () => navigation.navigate('Main' as never),
           },
           {
             text: 'Configure Menu',

--- a/CashApp-iOS/CashAppPOS/src/utils/componentRegistry.ts
+++ b/CashApp-iOS/CashAppPOS/src/utils/componentRegistry.ts
@@ -1,0 +1,38 @@
+/**
+ * Component Registry - Prevents tree-shaking of essential React Native components
+ * 
+ * This file ensures that critical React Native components are not removed
+ * by the Metro bundler's tree-shaking optimization, which can cause
+ * ReferenceError issues in production iOS builds.
+ */
+
+import { TextInput, ScrollView, KeyboardAvoidingView, FlatList } from 'react-native';
+
+// Global registry to prevent tree-shaking
+const ComponentRegistry = {
+  TextInput,
+  ScrollView,
+  KeyboardAvoidingView,
+  FlatList,
+};
+
+// Force references to prevent removal during optimization
+export const ensureComponentsLoaded = () => {
+  const components = [
+    'TextInput',
+    'ScrollView', 
+    'KeyboardAvoidingView',
+    'FlatList'
+  ];
+  
+  components.forEach(name => {
+    if (ComponentRegistry[name as keyof typeof ComponentRegistry]) {
+      console.log(`✅ ${name} component registered`);
+    } else {
+      console.error(`❌ ${name} component not found!`);
+    }
+  });
+};
+
+// Export registry for potential future use
+export default ComponentRegistry;


### PR DESCRIPTION
## What
- Fixed incorrect navigation route 'MainPOS' -> 'Main' (route didn't exist in navigation structure)
- Added TextInput import to App.tsx to prevent tree-shaking
- Created componentRegistry.ts utility to ensure critical React Native components are loaded
- Updated bundle version to v10

## Why
The TextInput ReferenceError was occurring at the end of the onboarding flow due to two issues:
1. The onboarding screen was navigating to 'MainPOS' which doesn't exist in the navigation structure
2. Metro bundler's tree-shaking was removing TextInput component in production builds

## Technical Details
- Created a component registry that forces references to TextInput, ScrollView, KeyboardAvoidingView, and FlatList
- The registry is initialized early in App.tsx to ensure components are available throughout the app
- Fixed navigation to use the correct 'Main' route which loads the MainNavigator

## Testing
1. Build the iOS bundle: `npx metro build index.js --platform ios --dev false --out ios/main.jsbundle`
2. Copy bundle: `mv ios/main.jsbundle.js ios/main.jsbundle && cp ios/main.jsbundle ios/CashAppPOS/main.jsbundle`
3. Run the iOS app and complete the onboarding flow
4. Verify no TextInput ReferenceError occurs when navigating from onboarding

## Related Issues
- Fixes the persistent TextInput error that remained after PR #376