### PR TITLE
Fix: Force rebuild to deploy SumUp rate limiter fix

### DIFF
--- a/backend/app/api/v1/endpoints/sumup.py
+++ b/backend/app/api/v1/endpoints/sumup.py
@@ -1,6 +1,8 @@
 """
 SumUp Payment Provider Initialization Endpoint
 Provides secure configuration for mobile app without exposing API keys
+
+Last updated: 2025-07-29 - Force rebuild after rate limiter fix
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request


### PR DESCRIPTION
## What
- Added timestamp comment to sumup.py to force DigitalOcean rebuild
- No actual code changes - the fix is already in main from PR #413

## Why
- Deployment failed after PR #413 was merged despite fix being correct
- DigitalOcean appears to be using a cached build
- Adding a timestamp comment forces a fresh build with the latest code

## The Original Fix (Already in Main)
- Added `request: Request` parameter to all rate-limited endpoints in sumup.py
- Renamed request body parameters to avoid naming conflicts
- Follows same pattern as other endpoints (payments.py, dashboard.py)

## Testing
- The fix has already been tested and is in main
- This PR just forces DigitalOcean to use the latest code
- Deployment should succeed once this PR triggers a fresh build