### PR TITLE
Fix: Enable production configuration validation (Issue #394)

### DIFF
--- a/digitalocean/app-spec-minimal-update.yaml
+++ b/digitalocean/app-spec-minimal-update.yaml
@@ -1,0 +1,28 @@
+# Minimal DigitalOcean App Spec Update for Production Validation
+# Issue #394 - Only add the missing ENVIRONMENT variable
+# 
+# Apply with: doctl apps update 04073e70-e799-4d27-873a-dadea0503858 --spec-file digitalocean/app-spec-minimal-update.yaml
+
+envs:
+  # This is the ONLY missing piece - add ENVIRONMENT=production
+  - key: ENVIRONMENT
+    value: production
+    scope: RUN_AND_BUILD_TIME
+    
+  # The following variables should already be properly set:
+  # - DEBUG (already set as secret - verify it's "false")
+  # - SECRET_KEY (already set as secret - should be strong)
+  # - SUMUP_ENVIRONMENT (already set as secret - verify it's "production")
+  
+  # Variables that are missing but recommended:
+  - key: ERROR_DETAIL_ENABLED
+    value: "false"
+    scope: RUN_AND_BUILD_TIME
+    
+  - key: LOG_LEVEL
+    value: INFO
+    scope: RUN_AND_BUILD_TIME
+    
+  - key: CORS_ORIGINS
+    value: "https://app.fynlo.co.uk,https://fynlo.co.uk,https://api.fynlo.co.uk,https://fynlo.vercel.app"
+    scope: RUN_AND_BUILD_TIME

--- a/digitalocean/app-spec-production-update.yaml
+++ b/digitalocean/app-spec-production-update.yaml
@@ -1,0 +1,29 @@
+# DigitalOcean App Spec Update for Production Validation
+# Issue #394 - Enable production configuration validation
+# 
+# This partial spec only includes the environment variables that need to be added/updated
+# Apply with: doctl apps update 04073e70-e799-4d27-873a-dadea0503858 --spec-file digitalocean/app-spec-production-update.yaml
+
+envs:
+  # CRITICAL: Enable production validation
+  - key: ENVIRONMENT
+    value: production
+    scope: RUN_AND_BUILD_TIME
+    
+  # Required for production validation to pass
+  - key: ERROR_DETAIL_ENABLED
+    value: "false"
+    scope: RUN_AND_BUILD_TIME
+    
+  - key: LOG_LEVEL
+    value: INFO
+    scope: RUN_AND_BUILD_TIME
+    
+  - key: CORS_ORIGINS
+    value: "https://app.fynlo.co.uk,https://fynlo.co.uk,https://api.fynlo.co.uk,https://fynlo.vercel.app"
+    scope: RUN_AND_BUILD_TIME
+
+  # Note: The following should already be set correctly, but listing for reference:
+  # - DEBUG: Must be "false" (already set as secret)
+  # - SECRET_KEY: Must be strong and >32 chars (already set as secret)
+  # - SUMUP_ENVIRONMENT: Should be "production" not "sandbox" (currently set as secret)

--- a/docs/production-validation-setup.md
+++ b/docs/production-validation-setup.md
@@ -1,0 +1,77 @@
+# Production Configuration Validation Setup
+
+## Issue #394 - HIGH Priority
+
+### Current Status
+After investigating the DigitalOcean App Platform configuration, I've confirmed that:
+- ✅ Production validation code exists in `backend/app/core/config.py`
+- ❌ `ENVIRONMENT` variable is NOT set in DigitalOcean
+- ⚠️ Without `ENVIRONMENT=production`, validation checks are bypassed
+
+### Required Actions
+
+#### 1. Add Missing Environment Variable
+The following environment variable MUST be added to DigitalOcean App Platform:
+
+```
+ENVIRONMENT=production
+```
+
+This will trigger the following validation checks on startup:
+- DEBUG mode must be False
+- ERROR_DETAIL_ENABLED must be False  
+- CORS origins must not contain wildcards
+- SECRET_KEY must not be default value
+- Secret key must be >32 characters
+- LOG_LEVEL should not be DEBUG
+- Payment keys must be production keys
+
+#### 2. Variables That Need Attention
+
+Based on the validation code, these variables need to be set properly:
+
+| Variable | Current Status | Required Action |
+|----------|---------------|-----------------|
+| `ENVIRONMENT` | ❌ Not set | Add: `production` |
+| `ERROR_DETAIL_ENABLED` | ❌ Not set | Add: `false` |
+| `CORS_ORIGINS` | ❌ Not set | Add: `https://app.fynlo.co.uk,https://fynlo.co.uk` |
+| `LOG_LEVEL` | ❌ Not set | Add: `INFO` |
+
+#### 3. Variables Already Set (Need Verification)
+
+These are already set as secrets but their values need verification:
+- `DEBUG` - Must be `false`
+- `SECRET_KEY` - Must be strong and >32 chars
+- `SUMUP_ENVIRONMENT` - Should be `production` not `sandbox`
+
+### How to Apply These Changes
+
+1. **Using DigitalOcean CLI:**
+```bash
+doctl apps update 04073e70-e799-4d27-873a-dadea0503858 --spec-file app-spec.yaml
+```
+
+2. **Using DigitalOcean Web Console:**
+   - Go to Apps → fynlopos → Settings → App-Level Environment Variables
+   - Add the missing variables listed above
+
+3. **Using the MCP Tool:**
+   - Use `mcp__digitalocean-mcp-local__apps-update` to add environment variables
+
+### Impact
+
+Once `ENVIRONMENT=production` is set:
+- The app will refuse to start if any validation check fails
+- This ensures secure configuration in production
+- Prevents accidental deployment of insecure settings
+
+### Testing
+
+After adding the environment variables:
+1. Monitor deployment logs for validation errors
+2. If validation fails, the app will show clear error messages
+3. Fix any reported issues before the app can start
+
+### Priority
+
+**HIGH** - Security validation is currently bypassed in production!

--- a/docs/production-validation-setup.md
+++ b/docs/production-validation-setup.md
@@ -7,6 +7,8 @@ After investigating the DigitalOcean App Platform configuration, I've confirmed 
 - ✅ Production validation code exists in `backend/app/core/config.py`
 - ❌ `ENVIRONMENT` variable is NOT set in DigitalOcean
 - ⚠️ Without `ENVIRONMENT=production`, validation checks are bypassed
+- ✅ Most required secrets are already set (DEBUG, SECRET_KEY, etc.)
+- ⚠️ Need to verify that DEBUG="false" and SUMUP_ENVIRONMENT="production"
 
 ### Required Actions
 

--- a/scripts/verify-production-config.sh
+++ b/scripts/verify-production-config.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Script to verify production configuration in DigitalOcean
+# Issue #394 - Production configuration validation
+
+APP_ID="04073e70-e799-4d27-873a-dadea0503858"
+
+echo "=== Verifying Production Configuration for Fynlo POS ==="
+echo "App ID: $APP_ID"
+echo ""
+
+# Check if doctl is installed
+if ! command -v doctl &> /dev/null; then
+    echo "ERROR: doctl CLI is not installed. Please install it first."
+    echo "Visit: https://docs.digitalocean.com/reference/doctl/how-to/install/"
+    exit 1
+fi
+
+echo "Fetching current app configuration..."
+APP_SPEC=$(doctl apps get $APP_ID --format json 2>/dev/null)
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to fetch app configuration. Please check your doctl authentication."
+    exit 1
+fi
+
+echo ""
+echo "=== Checking Critical Environment Variables ==="
+echo ""
+
+# Function to check if an env var exists
+check_env_var() {
+    local var_name=$1
+    local expected_value=$2
+    
+    if echo "$APP_SPEC" | jq -r '.[] | .spec.envs[]? | select(.key=="'$var_name'")' | grep -q "$var_name"; then
+        echo "✅ $var_name is set"
+        if [ ! -z "$expected_value" ]; then
+            # For non-secret values, we can check the actual value
+            actual_value=$(echo "$APP_SPEC" | jq -r '.[] | .spec.envs[]? | select(.key=="'$var_name'") | .value' 2>/dev/null)
+            if [[ "$actual_value" != *"EV["* ]]; then
+                if [ "$actual_value" == "$expected_value" ]; then
+                    echo "   ✅ Value is correct: $actual_value"
+                else
+                    echo "   ❌ Value mismatch - Expected: $expected_value, Got: $actual_value"
+                fi
+            else
+                echo "   ℹ️  Value is encrypted (secret)"
+            fi
+        fi
+    else
+        echo "❌ $var_name is NOT set"
+    fi
+}
+
+echo "Critical Variables for Production Validation:"
+echo "-------------------------------------------"
+check_env_var "ENVIRONMENT" "production"
+check_env_var "DEBUG"
+check_env_var "ERROR_DETAIL_ENABLED" "false"
+check_env_var "LOG_LEVEL" "INFO"
+check_env_var "CORS_ORIGINS"
+check_env_var "SECRET_KEY"
+check_env_var "SUMUP_ENVIRONMENT"
+
+echo ""
+echo "=== Summary ==="
+echo ""
+echo "If ENVIRONMENT is not set to 'production', the production validation will NOT run!"
+echo "This means security checks are bypassed."
+echo ""
+echo "To apply the required changes, run:"
+echo "doctl apps update $APP_ID --spec-file digitalocean/app-spec-production-update.yaml"
+echo ""


### PR DESCRIPTION
## Summary
This PR addresses HIGH priority issue #394 by providing the necessary documentation and tools to enable production configuration validation in DigitalOcean App Platform.

## Investigation Findings

After thorough investigation using DigitalOcean CLI and MCP tools:
- ✅ **Production validation code exists** in `backend/app/core/config.py` (lines 211-267)
- ❌ **`ENVIRONMENT` variable is NOT set** in DigitalOcean App Platform
- ⚠️ **Security validation is currently BYPASSED** because the app defaults to development mode

## What This PR Adds

1. **Documentation** (`docs/production-validation-setup.md`)
   - Clear explanation of the issue
   - List of required environment variables
   - Step-by-step instructions for applying changes

2. **DigitalOcean App Spec Update** (`digitalocean/app-spec-production-update.yaml`)
   - Ready-to-use configuration file
   - Adds missing `ENVIRONMENT=production` variable
   - Includes other required variables for validation to pass

3. **Verification Script** (`scripts/verify-production-config.sh`)
   - Checks current DigitalOcean configuration
   - Identifies missing or incorrect variables
   - Provides clear status report

## Critical Environment Variables Needed

| Variable | Current Status | Required Value |
|----------|---------------|----------------|
| `ENVIRONMENT` | ❌ Not set | `production` |
| `ERROR_DETAIL_ENABLED` | ❌ Not set | `false` |
| `CORS_ORIGINS` | ❌ Not set | `https://app.fynlo.co.uk,https://fynlo.co.uk` |
| `LOG_LEVEL` | ❌ Not set | `INFO` |

## Next Steps

1. **Merge this PR** to get the documentation and tools in place
2. **Apply the configuration** using one of these methods:
   - CLI: `doctl apps update 04073e70-e799-4d27-873a-dadea0503858 --spec-file digitalocean/app-spec-production-update.yaml`
   - Web Console: Apps → fynlopos → Settings → App-Level Environment Variables
   - MCP Tool: Use `mcp__digitalocean-mcp-local__apps-update`

3. **Monitor deployment** for validation errors and address any issues

## Impact

Once `ENVIRONMENT=production` is set:
- Production validation will run on every deployment
- App will refuse to start with insecure configuration
- Prevents accidental deployment of development settings

## Testing

Run `./scripts/verify-production-config.sh` to check current status before and after applying changes.

Fixes #394