### PR TITLE
Fix: Correct pybreaker version to resolve DigitalOcean build failure

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,7 +49,7 @@ celery==5.3.6
 # Monitoring & Logging - Latest versions
 python-dotenv==1.0.0
 python-json-logger==2.0.7
-pybreaker==6.1.0  # Circuit breaker for external API calls
+pybreaker==1.4.0  # Circuit breaker for external API calls
 
 # Validation Dependencies - Required for core validation
 jsonschema==4.21.1


### PR DESCRIPTION
## Summary
This PR fixes the DigitalOcean build failure by correcting the pybreaker version from 6.1.0 (which doesn't exist) to 1.4.0.

## What Changed
- Fixed pybreaker version in requirements.txt from 6.1.0 to 1.4.0

## Why
The DigitalOcean build was failing with:
```
ERROR: No matching distribution found for pybreaker==6.1.0
```

## Testing
- Verified pybreaker 1.4.0 exists in PyPI
- All security checks pass
- Build succeeds with this change