### PR TITLE
Fix: Add missing psutil dependency causing deployment failure

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -50,6 +50,7 @@ celery==5.3.6
 python-dotenv==1.0.0
 python-json-logger==2.0.7
 pybreaker==1.4.0  # Circuit breaker for external API calls
+psutil==5.9.8  # System monitoring for health checks
 
 # Validation Dependencies - Required for core validation
 jsonschema==4.21.1


### PR DESCRIPTION
## Problem
The deployment was failing at 9:07:22 with:
```
ModuleNotFoundError: No module named 'psutil'
```

This was causing the app to crash on startup and fail health checks.

## Solution
Added `psutil==5.9.8` to requirements.txt

## Root Cause
The health.py endpoint imports psutil but it wasn't included in the dependencies.

## Testing
- This will fix the deployment immediately upon merge
- The health endpoint will be able to report system metrics properly