### PR TITLE
Fix: Critical syntax error preventing backend deployment

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -558,7 +558,8 @@ async def process_stripe_payment(
             commit=False
         )
         logger.error(f"Stripe payment failed: {str(e)}")
-        raise ValidationException(message=f"Payment failed: {str(e)}")    except Exception as e:
+        raise ValidationException(message=f"Payment failed: {str(e)}")
+    except Exception as e:
         payment_db_record.status = "failed" # Ensure status is marked failed
         await audit_service.create_audit_log(
             event_type=AuditEventType.PAYMENT_FAILURE,


### PR DESCRIPTION
## What
- Fixed syntax error in payments.py line 561 where 'except Exception as e:' was incorrectly appended to a raise statement
- This was causing the backend to fail with SyntaxError during deployment

## Why
- The previous PR #456 introduced this syntax error
- Deployment was failing with: SyntaxError: invalid syntax
- The app was automatically rolling back to the previous deployment

## Testing
- Verified Python syntax with py_compile
- The fix separates the except clause to its own line properly

## Impact
- Critical fix needed to restore backend deployment
- No functional changes, only syntax correction