### PR TITLE
🚨 HOTFIX: Backend syntax error blocking deployment

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,7 +1,7 @@
 """
 Fynlo POS Backend Application
 FastAPI-based Point of Sale system for restaurants
-"""TODO: Add docstring."""
+"""
 
 __version__ = "1.0.0"
 __author__ = "Ryan Davidson"


### PR DESCRIPTION
## 🔥 Critical Issue
The backend deployment is currently failing due to a syntax error in `backend/app/__init__.py`.

## 🐛 Problem
- Unterminated triple-quoted string literal causing SyntaxError
- Backend service fails to start
- Health checks fail after 5 attempts
- Deployment blocked on DigitalOcean

## ✅ Solution
- Removed malformed docstring fragment `"""TODO: Add docstring."""`
- Fixed the unterminated string literal
- Verified import works correctly

## 🧪 Testing
```bash
cd backend && python3 -c "import app; print('Import successful')"
# Output: Import successful
```

## 🚀 Impact
This hotfix will allow the backend to start properly and unblock deployments.

**This needs to be merged ASAP to restore backend service.**