### PR TITLE
Fix: Resolve backend deployment syntax error

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@
 Fynlo POS Backend API
 Clean FastAPI implementation for hardware-free restaurant management
 Version: 2.1.0 - Portal alignment with optional PDF exports
-"""TODO: Add docstring."""
+"""
 
 from fastapi import FastAPI, Depends, status
 from fastapi.middleware.cors import CORSMiddleware


### PR DESCRIPTION
## What
- Fixed unterminated triple-quoted string literal in backend/app/main.py
- Removed duplicate TODO docstring that was breaking the Python syntax

## Why
- The backend deployment was failing with a SyntaxError on line 593
- The error was caused by an unclosed docstring at the beginning of the file
- Line 5 had `"""TODO: Add docstring."""` which interrupted the main docstring

## Testing
- Verified Python syntax with `python3 -m py_compile app/main.py`
- No syntax errors found after the fix

## Deployment Impact
This fix will allow the backend to start successfully on DigitalOcean.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>