### PR TITLE
Fix: Resolve backend deployment import error in core/__init__.py

### DIFF
--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,4 +1,18 @@
 """
 Core package for Fynlo POS
 Contains core functionality, database models, and utilities
-"""TODO: Add docstring."""
+"""
+
+from app.core.config import get_settings
+from app.core.database import get_db
+from app.core.response_helper import APIResponseHelper
+from app.core.exceptions import FynloException
+from app.core.websocket import websocket_manager
+
+__all__ = [
+    "get_settings",
+    "get_db",
+    "APIResponseHelper",
+    "FynloException",
+    "websocket_manager"
+]


### PR DESCRIPTION
## What
- Fixed missing imports in `backend/app/core/__init__.py`
- Added proper module exports for commonly used utilities

## Why
- The backend deployment was failing with ImportError
- The file only had a docstring but was missing the actual imports
- Other modules were trying to import: `get_settings`, `get_db`, `APIResponseHelper`, `FynloException`, `websocket_manager`

## Changes
- Added imports from respective modules:
  - `get_settings` from `config.py`
  - `get_db` from `database.py`
  - `APIResponseHelper` from `response_helper.py`
  - `FynloException` from `exceptions.py`
  - `websocket_manager` from `websocket.py`
- Added `__all__` declaration for proper module exports

## Testing
- Verified Python syntax is correct
- Checked that all imported modules exist in the core directory

## Deployment Impact
This fix will allow the backend to import required modules and start successfully on DigitalOcean.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>