### PR TITLE
Fix: Correct Order model imports causing deployment failure

### DIFF
--- a/backend/tests/test_example_full_coverage.py
+++ b/backend/tests/test_example_full_coverage.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 import redis
 import httpx
 
-from app.models.order import Order
+from app.core.database import Order
 from app.services.order_service import OrderService
 from app.api.endpoints.orders import router
 from tests.test_helpers import (

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -22,10 +22,7 @@ from fastapi.testclient import TestClient
 import httpx
 import redis
 
-from app.models.user import User
-from app.models.restaurant import Restaurant
-from app.models.order import Order
-from app.models.menu_item import MenuItem
+from app.core.database import User, Restaurant, Order, Product as MenuItem
 from app.core.security import create_access_token
 
 

--- a/backend/tests/test_patterns_guide.py
+++ b/backend/tests/test_patterns_guide.py
@@ -34,9 +34,7 @@ from app.main import app
 from app.core.database import Base, get_db
 from app.core.security import create_access_token, verify_token
 from app.core.redis_client import get_redis_client
-from app.models.user import User
-from app.models.restaurant import Restaurant
-from app.models.order import Order
+from app.core.database import User, Restaurant, Order
 from app.services.redis_service import RedisService
 from app.services.external_api import ExternalAPIClient
 from app.services.background_tasks import process_order_async


### PR DESCRIPTION
## Summary
This PR fixes the incorrect imports that were causing deployment failures. The deployment logs showed that the app was trying to import from `app.models.order` but failing.

## Root Cause
- Test files were importing Order from `app.models.order`
- The Order model is actually defined in `app.core.database`
- The deployment environment seems to have a different file structure

## Changes
Fixed imports in test files:
- `tests/test_example_full_coverage.py`
- `tests/test_helpers.py`
- `tests/test_patterns_guide.py`

Changed from:
```python
from app.models.order import Order
```

To:
```python
from app.core.database import Order
```

## Impact
This should resolve the ModuleNotFoundError preventing the backend from starting after deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>