### PR TITLE
Fix: Critical syntax errors in database_security.py preventing deployment

### DIFF
--- a/backend/app/core/database_security.py
+++ b/backend/app/core/database_security.py
@@ -218,7 +218,7 @@ class DatabaseSecurityConfig:
         
         Args:
             engine: SQLAlchemy engine instance
-        
+        """
         
         @event.listens_for(engine, "before_cursor_execute")
         def receive_before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
@@ -249,7 +249,7 @@ class DatabaseSecurityConfig:
         
         Args:
             engine: SQLAlchemy engine instance
-        
+        """
         
         @event.listens_for(engine, "before_cursor_execute")
         def receive_before_cursor_execute(conn, cursor, statement, parameters, context, executemany):

--- a/backend/app/core/redis_client.py
+++ b/backend/app/core/redis_client.py
@@ -1,10 +1,10 @@
 
-
-from app.core.exceptions import ServiceUnavailableError
+"""
 Redis client for caching, session management, and rate limiting.
 Connects to DigitalOcean Valkey (Redis compatible).
+"""
 
-
+from app.core.exceptions import ServiceUnavailableError
 import json
 import logging
 import time

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -3,7 +3,7 @@ Subscription models for Fynlo POS
 
 This module contains SQLAlchemy models for managing subscription plans,
 restaurant subscriptions, and usage tracking.
-
+"""
 
 from sqlalchemy import Column, Integer, String, DECIMAL, Boolean, TIMESTAMP, ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB


### PR DESCRIPTION
## Summary
This PR fixes the actual syntax errors that were preventing backend deployment.

## Root Cause
The deployment was failing with:
```
File "/workspace/backend/app/core/database_security.py", line 225
    """Monitor and restrict dangerous queries"""
       ^^^^^^^
SyntaxError: invalid syntax
```

## Fixes Applied
1. **database_security.py**: Fixed two unclosed docstrings
   - `apply_query_restrictions` method: Added missing closing quotes
   - `setup_monitoring` method: Added missing closing quotes

2. **redis_client.py**: Fixed missing docstring quotes
   - Module description was not wrapped in quotes

3. **subscription.py**: Fixed unclosed module docstring
   - Module docstring was missing closing quotes

## Verification
- All files now compile successfully with `python3 -m py_compile`
- Backend imports work without syntax errors
- No more syntax errors found in comprehensive check

This should finally fix the deployment failure.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>