### PR TITLE
Fix: Security monitor syntax error blocking deployment

### DIFF
--- a/backend/app/core/security_monitor.py
+++ b/backend/app/core/security_monitor.py
@@ -1,7 +1,7 @@
 """
 Security Monitoring and Audit Logging
 Tracks security events, access violations, and provides audit trail
-
+"""
 
 import json
 import logging
@@ -54,7 +54,7 @@ class SecurityEventType(str, Enum):
 class SecurityMonitor:
     """
     Central security monitoring and logging system
-    
+    """
     
     def __init__(self, redis_client: Optional[RedisClient] = None):
         self.redis = redis_client


### PR DESCRIPTION
## Summary
This PR fixes the next syntax error in the deployment chain after PR #493.

## Error
```
File "/workspace/backend/app/core/security_monitor.py", line 20
    """Types of security events to monitor"""
       ^^^^^
SyntaxError: invalid syntax
```

## Fix
Fixed two unclosed docstrings in security_monitor.py:
1. Module docstring at line 1 - added closing `"""`
2. SecurityMonitor class docstring at line 55 - added closing `"""`

## Status
This continues the pattern of fixing syntax errors one by one as the import chain progresses during deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>