### PR TITLE
Fix: Restaurant deletion endpoint docstring error

### DIFF
--- a/backend/app/api/v1/endpoints/restaurant_deletion.py
+++ b/backend/app/api/v1/endpoints/restaurant_deletion.py
@@ -41,7 +41,6 @@ async def delete_restaurant(
     
     Args:
         restaurant_id: Restaurant to delete
-"""
         force: Force deletion even with warnings (requires platform owner)
         current_user: Current authenticated user
         db: Database session
@@ -50,7 +49,6 @@ async def delete_restaurant(
         Success response or error with dependency information
     """
     # Validate restaurant_id format
-"""
     try:
         validate_uuid_format(restaurant_id)
     except ValueError:


### PR DESCRIPTION
## Summary
This PR fixes the next syntax error in the deployment chain after PR #494.

## Error
```
File "/workspace/backend/app/api/v1/endpoints/restaurant_deletion.py", line 45
    force: Force deletion even with warnings (requires platform owner)
IndentationError: unexpected indent
```

## Root Cause
The docstring was malformed with:
- Premature closing `"""` at line 44
- Args content outside the docstring
- Multiple orphaned `"""` markers

## Fix
Consolidated the docstring properly so all parameter documentation is inside it.

## Import Chain Progress
main.py → api.py → endpoints/restaurants.py → endpoints/restaurant_deletion.py ✅

Next error will likely be in another imported module.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>