### PR TITLE
fix: clean up remaining conflict markers from revert

### DIFF
--- a/backend/alembic/versions/010_add_row_level_security.py
+++ b/backend/alembic/versions/010_add_row_level_security.py
@@ -18,11 +18,7 @@ def upgrade():
     """
     Enable Row Level Security on all tenant-specific tables
     Platform owners (Ryan and Arnaud) bypass all RLS policies
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     # Tables that need RLS
     tables_needing_rls = [
@@ -114,11 +110,7 @@ def upgrade():
 def downgrade():
     """
     Disable Row Level Security
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     tables_with_rls = [
         'orders', 'order_items', 'products', 'categories', 'customers',

--- a/backend/alembic/versions/011_add_rls_session_variables.py
+++ b/backend/alembic/versions/011_add_rls_session_variables.py
@@ -4,11 +4,7 @@ Add RLS session variable support
 Revision ID: 011_add_rls_session_variables
 Revises: 010_add_row_level_security
 Create Date: 2024-01-29 10:00:00.000000
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from alembic import op
 import sqlalchemy as sa

--- a/backend/app/api/mobile/endpoints.py
+++ b/backend/app/api/mobile/endpoints.py
@@ -1,10 +1,7 @@
 """
 Mobile API Compatibility Layer for Fynlo POS
 Provides Odoo-style endpoints and mobile-optimized responses for iOS app
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,9 +1,6 @@
 """
 API Router for Fynlo POS Backend
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/admin.py
+++ b/backend/app/api/v1/endpoints/admin.py
@@ -1,9 +1,6 @@
 """
 Admin endpoints for payment provider management and analytics
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/auth_backup.py
+++ b/backend/app/api/v1/endpoints/auth_backup.py
@@ -1,9 +1,6 @@
 """
 Authentication endpoints for Fynlo POS
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/config.py
+++ b/backend/app/api/v1/endpoints/config.py
@@ -1,10 +1,7 @@
 """
 Configuration Management API Endpoints
 Provides endpoints for managing payment system configuration
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/customers.py
+++ b/backend/app/api/v1/endpoints/customers.py
@@ -1,9 +1,6 @@
 """
 Customer Management API endpoints for Fynlo POS
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -1,9 +1,6 @@
 """
 Dashboard API endpoints for Fynlo POS - Portal dashboard aggregation
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/employees.py
+++ b/backend/app/api/v1/endpoints/employees.py
@@ -1,10 +1,7 @@
 """
 Employee Management API endpoints for Fynlo POS Backend
 Handles employee CRUD operations, scheduling, time tracking, and performance metrics
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/exports.py
+++ b/backend/app/api/v1/endpoints/exports.py
@@ -1,10 +1,7 @@
 """
 Export API endpoints for Fynlo POS - Portal export functionality
 TEMPORARILY DISABLED DUE TO MISSING DEPENDENCIES
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/fees.py
+++ b/backend/app/api/v1/endpoints/fees.py
@@ -89,11 +89,7 @@ async def calculate_fees_for_order(
     """
     Calculates the detailed fee breakdown for a given order's subtotal and payment method.
     This endpoint determines processor fees, platform fees, and service charges.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
     # 1. Determine fee payment rules (who pays processor fee, is it part of SC)
     payment_method_setting = payment_config_service.get_payment_method_setting(

--- a/backend/app/api/v1/endpoints/files.py
+++ b/backend/app/api/v1/endpoints/files.py
@@ -1,10 +1,7 @@
 """
 File Upload API endpoints for Fynlo POS
 iOS-optimized base64 image upload endpoints
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/health.py
+++ b/backend/app/api/v1/endpoints/health.py
@@ -1,10 +1,7 @@
 """
 Health monitoring endpoints for tracking instance status and system health.
 Enhanced with security best practices and proper authentication.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/menu_optimized.py
+++ b/backend/app/api/v1/endpoints/menu_optimized.py
@@ -1,9 +1,6 @@
 """
 Optimized Menu API endpoints with caching and performance improvements
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/monitoring.py
+++ b/backend/app/api/v1/endpoints/monitoring.py
@@ -2,11 +2,7 @@
 Comprehensive monitoring endpoints for instance and deployment tracking.
 Provides real-time visibility into replica counts and system health.
 Enhanced with strict input validation and security measures.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import APIRouter, Depends, BackgroundTasks, Query, Body, Request
 from datetime import datetime, timezone

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -1,10 +1,7 @@
 """
 Push Notification API endpoints for Fynlo POS
 Device registration, notification sending, and preference management
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/platform.py
+++ b/backend/app/api/v1/endpoints/platform.py
@@ -1,10 +1,7 @@
 """
 Platform Management API endpoints for Fynlo POS
 Multi-tenant platform owner features for managing multiple restaurants
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/platform_admin.py
+++ b/backend/app/api/v1/endpoints/platform_admin.py
@@ -1,10 +1,7 @@
 """
 Platform administration endpoints for secure management
 Only accessible by existing platform owners with proper authentication
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/pos.py
+++ b/backend/app/api/v1/endpoints/pos.py
@@ -1,9 +1,6 @@
 """
 POS Session Management API endpoints for Fynlo POS
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/products.py
+++ b/backend/app/api/v1/endpoints/products.py
@@ -1,9 +1,6 @@
 """
 Products and Menu Management API endpoints for Fynlo POS
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/products_secure.py
+++ b/backend/app/api/v1/endpoints/products_secure.py
@@ -1,11 +1,7 @@
 """
 Secure version of products endpoint with proper tenant isolation
 This demonstrates how to fix the vulnerability in the existing products.py
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session

--- a/backend/app/api/v1/endpoints/public_menu.py
+++ b/backend/app/api/v1/endpoints/public_menu.py
@@ -1,10 +1,7 @@
 """
 Public Menu API endpoints for Fynlo POS
 These endpoints don't require authentication to allow menu loading before login
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/restaurant_deletion.py
+++ b/backend/app/api/v1/endpoints/restaurant_deletion.py
@@ -1,10 +1,7 @@
 """
 Safe Restaurant Deletion Endpoint
 Validates that a restaurant can be safely deleted without breaking critical dependencies
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/restaurant_switch.py
+++ b/backend/app/api/v1/endpoints/restaurant_switch.py
@@ -1,11 +1,7 @@
 """
 Restaurant Switching API for Multi-Restaurant Owners
 Only restaurant owners with multiple restaurants can use this endpoint
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session

--- a/backend/app/api/v1/endpoints/restaurants.py
+++ b/backend/app/api/v1/endpoints/restaurants.py
@@ -1,9 +1,6 @@
 """
 Restaurant Management API endpoints for Fynlo POS
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/rls_example.py
+++ b/backend/app/api/v1/endpoints/rls_example.py
@@ -1,11 +1,7 @@
 """
 Example endpoint showing proper RLS implementation
 This file demonstrates how to use RLS session variable isolation
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException

--- a/backend/app/api/v1/endpoints/secure_payment_provider_management.py
+++ b/backend/app/api/v1/endpoints/secure_payment_provider_management.py
@@ -1,11 +1,7 @@
 """
 Payment Provider Management Endpoints
 Handles configuration and testing of payment providers
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import APIRouter, Depends, status, Query
 from typing import Dict, Any, List, Optional

--- a/backend/app/api/v1/endpoints/storage_health.py
+++ b/backend/app/api/v1/endpoints/storage_health.py
@@ -1,11 +1,7 @@
 """
 Storage Health Check API endpoints
 Monitor DigitalOcean Spaces integration status
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import APIRouter, Depends
 from app.core.auth import get_current_user
@@ -21,11 +17,7 @@ async def storage_health_check(current_user: User = Depends(get_current_user)):
     """
     Check storage service health and configuration
     Requires authentication to prevent information disclosure
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     # Only allow platform owners to check health
     if current_user.role != "platform_owner":
@@ -62,11 +54,7 @@ async def get_file_count(
 ):
     """
     Get count of files in Spaces storage
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     # Only allow platform owners or restaurant owners
     if current_user.role not in ["platform_owner", "restaurant_owner"]:

--- a/backend/app/api/v1/endpoints/sumup.py
+++ b/backend/app/api/v1/endpoints/sumup.py
@@ -3,10 +3,7 @@ SumUp Payment Provider Initialization Endpoint
 Provides secure configuration for mobile app without exposing API keys
 
 Last updated: 2025-07-29 - Force rebuild after rate limiter fix
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/sync.py
+++ b/backend/app/api/v1/endpoints/sync.py
@@ -1,10 +1,7 @@
 """
 Offline Sync API endpoints for Fynlo POS
 Handles batch upload, conflict resolution, and offline synchronization
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/websocket.py
+++ b/backend/app/api/v1/endpoints/websocket.py
@@ -1,10 +1,7 @@
 """
 WebSocket API endpoints for Fynlo POS
 Real-time communication endpoints
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/websocket_enhanced.py
+++ b/backend/app/api/v1/endpoints/websocket_enhanced.py
@@ -1,10 +1,7 @@
 """
 Enhanced WebSocket API endpoints for Fynlo POS
 Implements heartbeat, reconnection, and improved connection management
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/endpoints/websocket_portal.py
+++ b/backend/app/api/v1/endpoints/websocket_portal.py
@@ -1,10 +1,6 @@
 """
 WebSocket endpoints for Fynlo Portal - Real-time updates for web dashboard
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from typing import Optional
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends, Query, Path

--- a/backend/app/api/v1/endpoints/websocket_rate_limit_patch.py
+++ b/backend/app/api/v1/endpoints/websocket_rate_limit_patch.py
@@ -1,11 +1,7 @@
 """
 WebSocket Rate Limiting Integration
 This module shows how to integrate rate limiting into the existing websocket.py
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 # Add these imports to websocket.py
 from fastapi import Path, Query, WebSocket, Depends

--- a/backend/app/api/v1/endpoints/websocket_secure.py
+++ b/backend/app/api/v1/endpoints/websocket_secure.py
@@ -1,11 +1,7 @@
 """
 Enhanced WebSocket Security with TenantSecurity module
 Ensures proper isolation while maintaining platform owner access
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import WebSocket, WebSocketDisconnect, Path, Query, Depends
 from sqlalchemy.orm import Session
@@ -123,11 +119,7 @@ async def handle_websocket_message_secure(
 class SecureWebSocketManager:
     """
     Enhanced WebSocket manager with tenant isolation
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     @staticmethod
     async def broadcast_to_restaurant_secure(

--- a/backend/app/api/v1/platform/__init__.py
+++ b/backend/app/api/v1/platform/__init__.py
@@ -10,10 +10,7 @@ This module provides endpoints for platform owners to manage:
 
 Note: These endpoints are NOT used by the mobile app.
 Mobile apps use the standard v1 API endpoints.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/platform/analytics.py
+++ b/backend/app/api/v1/platform/analytics.py
@@ -1,9 +1,6 @@
 """
 Platform analytics endpoints for dashboard insights.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/platform/financial.py
+++ b/backend/app/api/v1/platform/financial.py
@@ -1,9 +1,6 @@
 """
 Platform financial reporting endpoints.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/platform/restaurants.py
+++ b/backend/app/api/v1/platform/restaurants.py
@@ -1,9 +1,6 @@
 """
 Platform restaurant management endpoints.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/platform/subscriptions.py
+++ b/backend/app/api/v1/platform/subscriptions.py
@@ -1,9 +1,6 @@
 """
 Platform subscription management endpoints.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/platform/users.py
+++ b/backend/app/api/v1/platform/users.py
@@ -1,9 +1,6 @@
 """
 Platform user management endpoints.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/api/v1/subscriptions.py
+++ b/backend/app/api/v1/subscriptions.py
@@ -3,10 +3,7 @@ Subscription management API endpoints
 
 This module provides REST API endpoints for managing restaurant subscriptions,
 subscription plans, and usage tracking.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 from fastapi import APIRouter, Depends, Query

--- a/backend/app/core/analytics_engine.py
+++ b/backend/app/core/analytics_engine.py
@@ -1,10 +1,7 @@
 """
 Advanced Analytics Engine for Fynlo POS
 Real-time dashboard metrics optimized for mobile consumption
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,9 +1,6 @@
 """
 Authentication middleware for Supabase integration
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/cache_warmer.py
+++ b/backend/app/core/cache_warmer.py
@@ -1,11 +1,7 @@
 """
 Cache warming strategies for Fynlo POS.
 Pre-populates cache with frequently accessed data to improve performance.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import asyncio
 import logging

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,11 +1,5 @@
 """
 Configuration settings for Fynlo POS Backend
-<<<<<<< HEAD
-=======
-"""
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
-
-
 """
 import os
 from pydantic_settings import BaseSettings

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,10 +1,7 @@
 """
 Enhanced Exception Handling for Fynlo POS
 iOS-friendly error management with detailed error information
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/file_upload.py
+++ b/backend/app/core/file_upload.py
@@ -1,10 +1,7 @@
 """
 File Upload System for Fynlo POS
 Handles base64 image uploads from iOS with validation and processing
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/logging_filters.py
+++ b/backend/app/core/logging_filters.py
@@ -57,11 +57,7 @@ class SensitiveDataFilter(logging.Filter):
     It redacts values in the `extra` dictionary of a log record
     if their keys match any of the `redacted_keywords`.
     It also attempts to redact well-known sensitive patterns from the log message itself.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
     def __init__(self, name="", redacted_keywords=None, placeholder=REDACTION_PLACEHOLDER):
         super().__init__(name)

--- a/backend/app/core/mobile_id_mapping.py
+++ b/backend/app/core/mobile_id_mapping.py
@@ -1,11 +1,6 @@
 """
 Mobile ID Mapping System for Fynlo POS
 Provides collision-resistant UUID to integer conversion for mobile compatibility
-<<<<<<< HEAD
-
-
-=======
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 """
 
 import hashlib

--- a/backend/app/core/mobile_middleware.py
+++ b/backend/app/core/mobile_middleware.py
@@ -1,11 +1,7 @@
 """
 Mobile Compatibility Middleware for Fynlo POS
 Handles port compatibility and mobile-specific request processing
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -18,11 +14,7 @@ logger = logging.getLogger(__name__)
 class MobileCompatibilityMiddleware(BaseHTTPMiddleware):
     """
     Middleware to handle mobile app compatibility requirements
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self, app, enable_cors: bool = True, enable_port_redirect: bool = True):
         super().__init__(app)
@@ -93,11 +85,7 @@ class MobileCompatibilityMiddleware(BaseHTTPMiddleware):
 class JSONRPCCompatibilityMiddleware(BaseHTTPMiddleware):
     """
     Middleware to handle JSONRPC requests for Odoo compatibility
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """
@@ -145,11 +133,7 @@ class JSONRPCCompatibilityMiddleware(BaseHTTPMiddleware):
 class MobileDataOptimizationMiddleware(BaseHTTPMiddleware):
     """
     Middleware to optimize data payloads for mobile devices
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """

--- a/backend/app/core/onboarding_helper.py
+++ b/backend/app/core/onboarding_helper.py
@@ -1,10 +1,7 @@
 """
 Onboarding Helper for Fynlo POS
 Handles API responses for users without restaurants
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/platform_service.py
+++ b/backend/app/core/platform_service.py
@@ -1,10 +1,7 @@
 """
 Platform Management Service for Fynlo POS
 Handles multi-tenant operations and platform owner features
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/production_guard.py
+++ b/backend/app/core/production_guard.py
@@ -1,11 +1,7 @@
 """
 Production Guard Utility
 Ensures test/debug code is not executed in production environment
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from functools import wraps
 import asyncio

--- a/backend/app/core/push_notifications.py
+++ b/backend/app/core/push_notifications.py
@@ -1,10 +1,7 @@
 """
 Push Notification Service for Fynlo POS
 Apple Push Notification Service (APNs) integration for iOS alerts
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/rate_limit_config.py
+++ b/backend/app/core/rate_limit_config.py
@@ -1,11 +1,6 @@
 """
 Centralized rate limiting configuration for Fynlo POS backend.
 Provides endpoint-specific rate limits based on security and performance requirements.
-<<<<<<< HEAD
-
-
-=======
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 """
 
 from typing import Dict

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -1,10 +1,7 @@
 """
 Rate limiter for WebSocket connections
 Implements token bucket algorithm for message rate limiting
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/response_helper.py
+++ b/backend/app/core/response_helper.py
@@ -1,10 +1,7 @@
 """
 API Response Helper for Fynlo POS
 Standardizes API responses across the application
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/responses.py
+++ b/backend/app/core/responses.py
@@ -1,10 +1,7 @@
 """
 Standardized API Response System for Fynlo POS
 iOS-friendly response wrapper for consistent mobile app integration
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/rls_context.py
+++ b/backend/app/core/rls_context.py
@@ -1,10 +1,7 @@
 """
 Row Level Security Context Manager
 Sets PostgreSQL session variables for RLS policies
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/rls_middleware.py
+++ b/backend/app/core/rls_middleware.py
@@ -1,10 +1,6 @@
 """
 RLS Middleware for automatic session context management
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from typing import Callable, Optional
 from fastapi import Request, Response
@@ -21,11 +17,7 @@ class RLSMiddleware(BaseHTTPMiddleware):
     """
     Middleware to automatically set and clear RLS session context
     for all authenticated requests
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """

--- a/backend/app/core/rls_session_context.py
+++ b/backend/app/core/rls_session_context.py
@@ -1,11 +1,7 @@
 """
 RLS Session Context Management
 Ensures proper tenant isolation in connection pooling environments
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import contextvars
 from typing import Optional, Dict, Any
@@ -28,11 +24,7 @@ class RLSSessionContext:
     """
     Manages Row Level Security (RLS) session variables for proper tenant isolation
     in connection pooling environments
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     @staticmethod
     async def set_tenant_context(

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,10 +1,7 @@
 """
 Comprehensive security module for Fynlo POS backend.
 Handles environment filtering, input validation, password hashing, and security utilities.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """
@@ -54,11 +51,7 @@ class SafeEnvironmentFilter:
     """
     Filters environment variables to prevent exposure of sensitive data.
     Only whitelisted variables are accessible through public endpoints.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     # Safe environment variables that can be exposed in public endpoints
     PUBLIC_SAFE_VARS: Set[str] = {
@@ -166,11 +159,7 @@ class SafeEnvironmentFilter:
 class InputValidator:
     """
     Comprehensive input validation utilities to prevent injection attacks.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     # Dangerous characters for different contexts
     SQL_DANGEROUS_CHARS = ["'", '"', ";", "--", "/*", "*/", "\\"]
@@ -270,10 +259,7 @@ class TokenEncryption:
     """
     Secure token encryption for storing sensitive tokens like API keys.
     Uses Fernet symmetric encryption with key derivation.
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
 """
@@ -336,10 +322,7 @@ class TokenEncryption:
 class WebhookSecurity:
     """
     Webhook signature verification and security utilities.
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
 """

--- a/backend/app/core/supabase.py
+++ b/backend/app/core/supabase.py
@@ -1,9 +1,6 @@
 """
 Supabase client configuration for authentication
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/sync_manager.py
+++ b/backend/app/core/sync_manager.py
@@ -1,10 +1,7 @@
 """
 Offline Sync Manager for Fynlo POS
 Handles batch upload, conflict resolution, and offline synchronization
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/tenant_security.py
+++ b/backend/app/core/tenant_security.py
@@ -4,10 +4,7 @@ Ensures proper multi-tenant isolation while maintaining platform owner access
 
 Platform Owners (Ryan and Arnaud) have FULL access to everything.
 All other users are restricted to their own restaurant's data.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/transaction_manager.py
+++ b/backend/app/core/transaction_manager.py
@@ -1,10 +1,7 @@
 """
 Database Transaction Management for Fynlo POS
 Provides decorators and utilities for atomic operations and rollback handling.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """
@@ -36,10 +33,7 @@ class TransactionManager:
     """
     Manages database transactions with retry logic, rollback handling,
     and atomic operation support.
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
 """
@@ -248,10 +242,7 @@ def optimistic_lock_retry(version_field: str = 'version', max_retries: int = 5):
 class BatchTransactionManager:
     """
     Manages batch operations with transaction boundaries and partial failure handling.
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
 """

--- a/backend/app/core/two_factor_auth.py
+++ b/backend/app/core/two_factor_auth.py
@@ -1,11 +1,7 @@
 """
 Two-Factor Authentication for Platform Owners
 Implements TOTP (Time-based One-Time Password) for Ryan and Arnaud
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import pyotp
 import qrcode
@@ -28,11 +24,7 @@ RECOVERY_CODE_LENGTH = 8
 class TwoFactorAuth:
     """
     Manages 2FA for platform owners
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self, redis_client: Optional[RedisClient] = None):
         self.redis = redis_client

--- a/backend/app/core/websocket.py
+++ b/backend/app/core/websocket.py
@@ -1,10 +1,7 @@
 """
 WebSocket Manager for Fynlo POS
 Real-time communication for orders, payments, kitchen updates, and notifications
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/core/websocket_rate_limiter.py
+++ b/backend/app/core/websocket_rate_limiter.py
@@ -1,11 +1,7 @@
 """
 WebSocket Rate Limiting System
 Prevents DoS attacks by limiting connections and messages
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import asyncio
 import time
@@ -23,11 +19,7 @@ logger = logging.getLogger(__name__)
 class WebSocketRateLimiter:
     """
     Comprehensive rate limiting for WebSocket connections and messages
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self, redis_client: Optional[RedisClient] = None):
         self.redis = redis_client

--- a/backend/app/crud/payments.py
+++ b/backend/app/crud/payments.py
@@ -1,9 +1,6 @@
 """
 CRUD operations for payments and provider analytics
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/integration/notification_events.py
+++ b/backend/app/integration/notification_events.py
@@ -1,10 +1,7 @@
 """
 Notification Event Integration for Fynlo POS
 Connects backend services with push notification sending
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/integration/websocket_events.py
+++ b/backend/app/integration/websocket_events.py
@@ -1,10 +1,7 @@
 """
 WebSocket Event Integration for Fynlo POS
 Connects backend services with WebSocket notifications
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/main_minimal.py
+++ b/backend/app/main_minimal.py
@@ -1,10 +1,7 @@
 """
 Minimal FastAPI app for DigitalOcean deployment
 No external dependencies, immediate startup
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/main_simple.py
+++ b/backend/app/main_simple.py
@@ -1,10 +1,7 @@
 """
 Simplified Fynlo POS Backend for DigitalOcean deployment
 Minimal version to ensure successful startup and health checks
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/middleware/feature_gate.py
+++ b/backend/app/middleware/feature_gate.py
@@ -3,10 +3,7 @@ Feature gating middleware for subscription-based access control
 
 This module provides decorators and middleware for restricting access
 to features based on subscription plans.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/middleware/rls_middleware.py
+++ b/backend/app/middleware/rls_middleware.py
@@ -1,11 +1,7 @@
 """
 RLS (Row Level Security) Middleware for Fynlo POS
 Automatically sets session variables for database RLS policies
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from fastapi import Request, Depends
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -24,11 +20,7 @@ class RLSMiddleware(BaseHTTPMiddleware):
     """
     Middleware to automatically set RLS context based on authenticated user.
     This ensures that all database queries in a request have proper tenant isolation.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     async def dispatch(self, request: Request, call_next):
         # Skip RLS for public endpoints

--- a/backend/app/middleware/sql_injection_waf.py
+++ b/backend/app/middleware/sql_injection_waf.py
@@ -23,11 +23,7 @@ class SQLInjectionWAFMiddleware(BaseHTTPMiddleware):
     """
     Web Application Firewall middleware to detect and block SQL injection attempts.
     This provides defense-in-depth security in addition to parameterized queries.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     # SQL injection patterns to detect
     SQL_INJECTION_PATTERNS = [

--- a/backend/app/middleware/tenant_isolation_middleware.py
+++ b/backend/app/middleware/tenant_isolation_middleware.py
@@ -2,11 +2,6 @@
 Tenant Isolation Middleware
 Ensures all API requests are properly isolated by restaurant
 Platform owners (Ryan and Arnaud) bypass all restrictions
-<<<<<<< HEAD
-
-
-=======
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 """
 
 from fastapi import Request, Response
@@ -24,10 +19,7 @@ logger = logging.getLogger(__name__)
 class TenantIsolationMiddleware(BaseHTTPMiddleware):
     """
     Middleware to enforce tenant isolation across all API endpoints
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
     """
@@ -88,10 +80,7 @@ class TenantIsolationMiddleware(BaseHTTPMiddleware):
 class TenantValidationMiddleware:
     """
     Additional middleware to validate tenant access in request payloads
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
     """

--- a/backend/app/middleware/version_middleware.py
+++ b/backend/app/middleware/version_middleware.py
@@ -20,11 +20,7 @@ class APIVersionMiddleware:
     - WebSocket path normalization
     - Version header detection
     - Graceful fallback mechanisms
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self, app):
         self.app = app
@@ -67,11 +63,7 @@ class APIVersionMiddleware:
         /api/products -> /api/v1/products
         /api/v1/products -> /api/v1/products (unchanged)
         /health -> /health (unchanged)
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         # Pattern for unversioned API calls
         unversioned_pattern = r'^/api/(?!v\d+/)(.+)$'
@@ -92,11 +84,7 @@ class APIVersionMiddleware:
         Examples:
         /ws/{restaurant_id} -> /api/v1/websocket/ws/{restaurant_id}
         /websocket/{restaurant_id} -> /api/v1/websocket/ws/{restaurant_id}
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         # Pattern for direct WebSocket paths
         ws_patterns = [
@@ -117,11 +105,7 @@ class APIVersionMiddleware:
         Checks for:
         - X-API-Version header
         - Accept header with version
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         # Check X-API-Version header
         api_version = request.headers.get("x-api-version")
@@ -140,11 +124,7 @@ class APIVersionMiddleware:
 def add_version_headers_to_response(request: Request, response: Response) -> Response:
     """
     Add version information to response headers
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     # Add current API version to response
     response.headers["X-API-Version"] = "1"
@@ -159,11 +139,7 @@ def add_version_headers_to_response(request: Request, response: Response) -> Res
 class WebSocketPathNormalizer:
     """
     Utility class for WebSocket path normalization
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     @staticmethod
     def normalize_ws_path(path: str, restaurant_id: str, connection_type: str = "general") -> str:
@@ -177,11 +153,7 @@ class WebSocketPathNormalizer:
             
         Returns:
             Normalized path
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         base_path = f"/api/v1/websocket/ws"
         
@@ -194,11 +166,7 @@ class WebSocketPathNormalizer:
     def extract_restaurant_id_from_path(path: str) -> Optional[str]:
         """
         Extract restaurant ID from WebSocket path
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         patterns = [
             r'/ws/([^/]+)',

--- a/backend/app/middleware/websocket_rate_limit.py
+++ b/backend/app/middleware/websocket_rate_limit.py
@@ -1,11 +1,7 @@
 """
 WebSocket Rate Limiting Module
 Implements rate limiting for WebSocket connections and messages to prevent DoS attacks
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import logging
 import time
@@ -33,11 +29,7 @@ class WebSocketRateLimiter:
     """
     Rate limiter for WebSocket connections and messages
     Uses Redis for distributed rate limiting across multiple servers
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self):
         # Connection limits

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,9 +1,6 @@
 """
 Models module - imports all models from database.py for convenience
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/models/activity_log.py
+++ b/backend/app/models/activity_log.py
@@ -1,9 +1,6 @@
 """
 Portal Activity Log model for audit trail
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/models/platform_audit.py
+++ b/backend/app/models/platform_audit.py
@@ -1,10 +1,7 @@
 """
 Platform audit logging model and functions.
 Tracks all platform admin actions for compliance and security.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/models/platform_config.py
+++ b/backend/app/models/platform_config.py
@@ -1,11 +1,7 @@
 """
 Platform Configuration Models
 Centralized settings managed by Fynlo platform
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 from sqlalchemy import Column, String, Boolean, DateTime, Text, JSON, Numeric, Index
 from sqlalchemy.dialects.postgresql import UUID

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,9 +1,6 @@
 """
 Authentication schemas for Supabase integration
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/schemas/employee_schemas.py
+++ b/backend/app/schemas/employee_schemas.py
@@ -1,10 +1,7 @@
 """
 Pydantic schemas for Employee Management API
 Defines request/response models for employee operations
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/schemas/restaurant.py
+++ b/backend/app/schemas/restaurant.py
@@ -1,9 +1,6 @@
 """
 Restaurant schemas for Fynlo POS
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -3,10 +3,7 @@ Subscription schemas for API request/response validation
 
 This module contains Pydantic models for validating subscription-related
 API requests and responses.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/schemas/websocket.py
+++ b/backend/app/schemas/websocket.py
@@ -1,9 +1,6 @@
 """
 WebSocket schemas for Fynlo POS
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/scripts/initialize_platform_defaults.py
+++ b/backend/app/scripts/initialize_platform_defaults.py
@@ -3,11 +3,7 @@
 Platform Defaults Initialization Script
 Sets up the platform with production-ready default configurations
 Safe to run multiple times - will not overwrite existing configurations
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 import sys
@@ -186,11 +182,7 @@ DATABASE STATE:
 - Total Feature Flags: {self.db.query(PlatformFeatureFlag).count()}
 
 STATUS: {'SUCCESS' if self.stats['errors'] == 0 else 'COMPLETED WITH ERRORS'}
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         print(report)
         logger.info("Platform initialization report generated")

--- a/backend/app/scripts/migrate_to_platform_settings.py
+++ b/backend/app/scripts/migrate_to_platform_settings.py
@@ -3,11 +3,7 @@
 Platform Settings Migration Script
 Migrates existing restaurant settings to the new platform-controlled architecture
 CRITICAL: Run this script during low-traffic hours to avoid payment processing disruption
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 import sys
@@ -460,11 +456,7 @@ Next Steps:
 5. Update restaurant owners about new platform-controlled settings
 
 For support, contact the development team with this report.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         with open(report_filename, 'w') as f:
             f.write(report_content)

--- a/backend/app/scripts/validate_migration.py
+++ b/backend/app/scripts/validate_migration.py
@@ -3,11 +3,7 @@
 Migration Validation Script
 Comprehensive validation of the platform settings migration
 Checks data integrity, API functionality, and configuration consistency
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 import sys
@@ -528,11 +524,7 @@ DATABASE STATISTICS:
 
 VALIDATION STATUS: {'PASSED' if self.validation_results['tests_failed'] == 0 else 'FAILED'}
 
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         if self.validation_results['errors']:
             report_content += "\nERRORS:\n"
@@ -556,11 +548,7 @@ Next Steps:
 5. Update documentation with new platform settings
 
 For support, contact the development team with this report.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         with open(report_filename, 'w') as f:
             f.write(report_content)

--- a/backend/app/services/activity_logger.py
+++ b/backend/app/services/activity_logger.py
@@ -1,9 +1,6 @@
 """
 Activity logging service for Fynlo Portal - Audit trail for portal actions
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/config_manager.py
+++ b/backend/app/services/config_manager.py
@@ -1,10 +1,7 @@
 """
 Configuration Manager for Payment Providers
 Centralized configuration management with environment support and validation
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/digitalocean_monitor.py
+++ b/backend/app/services/digitalocean_monitor.py
@@ -2,11 +2,7 @@
 DigitalOcean App Platform monitoring service.
 Provides direct API access to get accurate instance counts and deployment status.
 Enhanced with security best practices and resilience patterns.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 import logging
@@ -62,11 +58,7 @@ class DigitalOceanMonitor:
     - Circuit breaker pattern
     - Input validation
     - Proper error handling
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self):
         # Load and decrypt API token securely

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,10 +1,7 @@
 """
 Email Service using Resend API for Fynlo POS
 Handles transactional emails including receipt delivery
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/employee_service.py
+++ b/backend/app/services/employee_service.py
@@ -1,10 +1,7 @@
 """
 Employee Service - Business logic for employee management
 Handles employee CRUD operations, scheduling, time tracking, and performance metrics
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/financial_records_service.py
+++ b/backend/app/services/financial_records_service.py
@@ -11,11 +11,7 @@ logger = logging.getLogger(__name__)
 class FinancialRecordsService:
     """
     Service for managing financial records like platform fees and staff tip distributions.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
     def __init__(self, db: Session):
         self.db = db

--- a/backend/app/services/instance_tracker.py
+++ b/backend/app/services/instance_tracker.py
@@ -1,11 +1,6 @@
 """
 Instance tracking service for monitoring active backend instances.
 Tracks instances using Redis with heartbeat mechanism.
-<<<<<<< HEAD
-
-
-=======
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 """
 
 import asyncio
@@ -29,10 +24,7 @@ class InstanceTracker:
     
     Each instance registers itself with Redis and maintains a heartbeat.
     Stale instances are automatically cleaned up based on TTL.
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
     """

--- a/backend/app/services/monitoring.py
+++ b/backend/app/services/monitoring.py
@@ -1,10 +1,7 @@
 """
 Monitoring and Alerting Service for Payment System
 Tracks metrics, health, and sends alerts for payment-related issues
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/payment_analytics.py
+++ b/backend/app/services/payment_analytics.py
@@ -1,10 +1,7 @@
 """
 Advanced Payment Analytics Service
 Provides detailed insights into payment performance, cost optimization, and provider analytics
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/payment_config_service.py
+++ b/backend/app/services/payment_config_service.py
@@ -12,11 +12,7 @@ class PaymentConfigService:
     """
     Service for managing payment method fee configurations.
     These settings determine how processor fees are handled (e.g., who pays, toggling).
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
     def __init__(self, db: Session):
         self.db = db

--- a/backend/app/services/payment_fee_calculator.py
+++ b/backend/app/services/payment_fee_calculator.py
@@ -11,11 +11,7 @@ class PaymentFeeCalculator:
     """
     Calculates the actual payment processor fees.
     This fee is what the platform itself is charged by the payment provider (e.g., Stripe, SumUp).
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
     def __init__(self, platform_settings_service: PlatformSettingsService):
         self.platform_settings_service = platform_settings_service

--- a/backend/app/services/payment_providers/__init__.py
+++ b/backend/app/services/payment_providers/__init__.py
@@ -1,9 +1,6 @@
 """
 Payment Provider Implementations
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/payment_providers/base.py
+++ b/backend/app/services/payment_providers/base.py
@@ -1,9 +1,6 @@
 """
 Base Payment Provider Abstract Class
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/payment_providers/payment_factory.py
+++ b/backend/app/services/payment_providers/payment_factory.py
@@ -1,9 +1,6 @@
 """
 Payment Provider Factory with Smart Routing
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/payment_providers/square_provider.py
+++ b/backend/app/services/payment_providers/square_provider.py
@@ -1,9 +1,6 @@
 """
 Square Payment Provider Implementation
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/payment_providers/stripe_provider.py
+++ b/backend/app/services/payment_providers/stripe_provider.py
@@ -1,9 +1,6 @@
 """
 Stripe Payment Provider Implementation
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/payment_providers/sumup_provider.py
+++ b/backend/app/services/payment_providers/sumup_provider.py
@@ -1,9 +1,6 @@
 """
 SumUp Payment Provider Implementation
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/platform_fee_service.py
+++ b/backend/app/services/platform_fee_service.py
@@ -11,11 +11,7 @@ logger = logging.getLogger(__name__)
 class PlatformFeeService:
     """
     Calculates the platform's transaction fee and the final customer total.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
     # PLATFORM_FEE_RATE should ideally be fetched from PlatformSettingsService
     # For example, as a config key like 'platform.transaction_fee.rate'

--- a/backend/app/services/platform_service.py
+++ b/backend/app/services/platform_service.py
@@ -1,10 +1,7 @@
 """
 Platform Settings Service
 Manages centralized platform configurations and restaurant overrides
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1,10 +1,7 @@
 """
 Report Aggregation Service
 Generates and populates DailyReport and HourlyMetric models from actual order data
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/secure_payment_config.py
+++ b/backend/app/services/secure_payment_config.py
@@ -43,11 +43,7 @@ class SecurePaymentConfigService:
     - Provides secure storage and retrieval
     - Validates configuration before storage
     - Audit trail for configuration changes
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self, db: Session):
         self.db = db

--- a/backend/app/services/secure_payment_processor.py
+++ b/backend/app/services/secure_payment_processor.py
@@ -92,11 +92,7 @@ class SecurePaymentProcessor:
     - Fee calculation and transparency
     - Security validation at every step
     - Database transaction management
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(self, db: Session, request_context: Optional[Dict[str, Any]] = None):
         self.db = db

--- a/backend/app/services/service_charge_calculator.py
+++ b/backend/app/services/service_charge_calculator.py
@@ -11,11 +11,7 @@ logger = logging.getLogger(__name__)
 class ServiceChargeCalculator:
     """
     Calculates the service charge, potentially including transaction fees.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 """
     def __init__(

--- a/backend/app/services/smart_routing.py
+++ b/backend/app/services/smart_routing.py
@@ -1,11 +1,7 @@
 """
 Smart Payment Routing Service
 Advanced algorithms for optimal payment provider selection based on multiple factors
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import logging
 from datetime import datetime, timedelta
@@ -100,11 +96,7 @@ class SmartRoutingService:
     ) -> RoutingDecision:
         """
         Make intelligent routing decision based on multiple factors
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         if force_provider:
             return RoutingDecision(
@@ -138,11 +130,7 @@ class SmartRoutingService:
     ) -> Dict:
         """
         Get comprehensive routing recommendations for a restaurant
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         end_date = datetime.utcnow()
         start_date = end_date - timedelta(days=analysis_period_days)
@@ -190,11 +178,7 @@ class SmartRoutingService:
     ) -> Dict:
         """
         Simulate the impact of changing routing strategy
-<<<<<<< HEAD
-        
-=======
         """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
         
         # Get historical transactions
         end_date = datetime.utcnow()

--- a/backend/app/services/staff_tip_service.py
+++ b/backend/app/services/staff_tip_service.py
@@ -13,11 +13,7 @@ class StaffTipService:
     """
     Manages the distribution of tips to staff members,
     accounting for service charges and transaction fees.
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 """
     def __init__(self, db: Session):

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -1,10 +1,7 @@
 """
 DigitalOcean Spaces Storage Service
 Handles file uploads, downloads, and management with CDN delivery
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -24,10 +24,7 @@ if TYPE_CHECKING:
 class SyncService:
     """
     Manages bidirectional data synchronization between platform and restaurants
-<<<<<<< HEAD
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     
 """

--- a/backend/app/services/volume_tracker.py
+++ b/backend/app/services/volume_tracker.py
@@ -1,10 +1,7 @@
 """
 Transaction Volume Tracking Service
 Tracks payment volumes, patterns, and triggers for routing optimization
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/simple_main.py
+++ b/backend/app/simple_main.py
@@ -1,10 +1,7 @@
 """
 Minimal Fynlo Backend for Immediate Cross-Device Sync Testing
 This version starts with just PostgreSQL connection to prove the concept
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/app/tasks/replica_validator.py
+++ b/backend/app/tasks/replica_validator.py
@@ -1,11 +1,7 @@
 """
 Automated replica count validation service.
 Monitors instance counts and sends alerts for discrepancies.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import asyncio
 import logging
@@ -29,11 +25,7 @@ class ReplicaValidator:
     - Active instance count from heartbeats
     - Configured replica count from DigitalOcean
     - Sends alerts when mismatches detected
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     def __init__(
         self, 
@@ -281,11 +273,7 @@ class ReplicaValidator:
             </ol>
             
             <p><small>Alert generated at: {alert_data['timestamp']}</small></p>
-<<<<<<< HEAD
-            
-=======
             """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
             
             await send_email(
                 to=settings.PLATFORM_OWNER_EMAIL,

--- a/backend/app/websocket/__init__.py
+++ b/backend/app/websocket/__init__.py
@@ -1,8 +1,4 @@
 """
 WebSocket package
-<<<<<<< HEAD
-
-=======
 Alternative WebSocket implementation for real-time communication
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 """

--- a/backend/get_supabase_token.py
+++ b/backend/get_supabase_token.py
@@ -1,10 +1,7 @@
 """
 Helper script to get a Supabase access token for testing
 This simulates what the mobile app will do
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/minimal_app.py
+++ b/backend/minimal_app.py
@@ -1,10 +1,7 @@
 """
 Minimal FastAPI server to get essential endpoints working
 This bypasses complex payment provider imports and focuses on core data endpoints
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/minimal_server.py
+++ b/backend/minimal_server.py
@@ -2,10 +2,7 @@
 """
 Minimal Backend Server for Fynlo POS Testing
 Provides essential endpoints without complex dependencies
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/analyze_exception_usage.py
+++ b/backend/scripts/analyze_exception_usage.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Analyze exception usage to find migration issues
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/check_httpexception_usage.py
+++ b/backend/scripts/check_httpexception_usage.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Script to check HTTPException usage and suggest FynloException replacements
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/create_restaurant.py
+++ b/backend/scripts/create_restaurant.py
@@ -2,11 +2,7 @@
 """
 Create Restaurant Script
 Creates a restaurant with proper configuration in the database
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 import sys

--- a/backend/scripts/detailed_exception_analysis.py
+++ b/backend/scripts/detailed_exception_analysis.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Generate detailed exception usage analysis with file and line information
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/fix_exception_migration.py
+++ b/backend/scripts/fix_exception_migration.py
@@ -8,10 +8,7 @@ HTTPException to FynloException migration.
 The main issue is that specialized exception classes (AuthenticationException,
 ValidationException, etc.) don't accept a 'code' parameter, but many files
 are still trying to pass it.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/fix_final_httpexceptions.py
+++ b/backend/scripts/fix_final_httpexceptions.py
@@ -2,10 +2,7 @@
 """
 Fix final remaining HTTPExceptions in core modules.
 This script targets the last HTTPExceptions that need to be migrated to FynloException.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/fix_remaining_httpexceptions.py
+++ b/backend/scripts/fix_remaining_httpexceptions.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 """
 Fix all remaining HTTPExceptions in core modules
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 import re

--- a/backend/scripts/link_supabase_users.py
+++ b/backend/scripts/link_supabase_users.py
@@ -2,10 +2,7 @@
 """
 Script to link existing Supabase users to database records
 This ensures users can authenticate with Supabase while maintaining data integrity
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/migrate_files_to_spaces.py
+++ b/backend/scripts/migrate_files_to_spaces.py
@@ -2,10 +2,7 @@
 """
 File migration script - Move existing local files to DigitalOcean Spaces
 Run this script to migrate existing uploads to cloud storage
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/migrate_httpexception_to_fynlo_v2.py
+++ b/backend/scripts/migrate_httpexception_to_fynlo_v2.py
@@ -2,10 +2,7 @@
 """
 Enhanced Migration Script: HTTPException to FynloException
 Version 2.0 - Improved import handling and file integrity
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/migrate_mexican_menu.py
+++ b/backend/scripts/migrate_mexican_menu.py
@@ -13,10 +13,7 @@ Requirements:
     - Backend database connection configured
     - SQLAlchemy models for menu items and categories
     - Restaurant tenant ID for Mexican restaurant
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/migrate_test_users.py
+++ b/backend/scripts/migrate_test_users.py
@@ -15,11 +15,7 @@ Requirements:
     - SQLAlchemy models for users and authentication
     - Password hashing utilities
     - Restaurant and platform models
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import json
 import sys

--- a/backend/scripts/optimize_database.py
+++ b/backend/scripts/optimize_database.py
@@ -2,11 +2,7 @@
 """
 Database Optimization Script for Fynlo POS
 Adds indexes, analyzes tables, and optimizes performance
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
@@ -59,11 +55,7 @@ def analyze_table_sizes(cursor):
     WHERE schemaname = 'public'
     ORDER BY pg_total_relation_size(schemaname||'.'||tablename) DESC
     LIMIT 20;
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     cursor.execute(query)
     results = cursor.fetchall()
@@ -104,11 +96,7 @@ def check_missing_indexes(cursor):
                 AND indexdef LIKE '%' || kcu.column_name || '%'
         )
     ORDER BY tc.table_name, kcu.column_name;
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     cursor.execute(query)
     missing_fk_indexes = cursor.fetchall()
@@ -220,11 +208,7 @@ def analyze_slow_queries(cursor):
         AND mean_exec_time > 100  -- Queries averaging over 100ms
     ORDER BY mean_exec_time DESC
     LIMIT 10;
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     try:
         cursor.execute(query)

--- a/backend/scripts/optimize_database_standalone.py
+++ b/backend/scripts/optimize_database_standalone.py
@@ -2,10 +2,7 @@
 """
 Standalone Database Optimization Script for Fynlo POS
 Works without app dependencies
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """
@@ -56,11 +53,7 @@ def analyze_table_sizes(cursor):
     WHERE schemaname = 'public'
     ORDER BY pg_total_relation_size(schemaname||'.'||tablename) DESC
     LIMIT 20;
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     cursor.execute(query)
     results = cursor.fetchall()
@@ -107,11 +100,7 @@ def check_existing_indexes(cursor):
     FROM pg_indexes
     WHERE schemaname = 'public'
     ORDER BY tablename, indexname;
-<<<<<<< HEAD
-    
-=======
     """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     cursor.execute(query)
     indexes = cursor.fetchall()

--- a/backend/scripts/optimize_redis.py
+++ b/backend/scripts/optimize_redis.py
@@ -2,11 +2,7 @@
 """
 Redis Optimization Script for Fynlo POS
 Configures eviction policies and monitors usage
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import redis
 import json
@@ -250,11 +246,7 @@ tcp-keepalive 60
 rename-command FLUSHDB ""
 rename-command FLUSHALL ""
 rename-command CONFIG ""
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
     
     print(config)
     

--- a/backend/scripts/seed_database.py
+++ b/backend/scripts/seed_database.py
@@ -2,10 +2,7 @@
 """
 Master Database Seeding Script for Fynlo POS
 Creates comprehensive production-like data for testing and development
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/seed_menu.py
+++ b/backend/scripts/seed_menu.py
@@ -2,11 +2,7 @@
 """
 Seed Menu Script
 Seeds menu data (categories and products) for a restaurant
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 import sys

--- a/backend/scripts/seed_orders_customers.py
+++ b/backend/scripts/seed_orders_customers.py
@@ -2,10 +2,7 @@
 """
 Focused seed script for Orders and Customers
 Creates realistic historical transaction data for reports to function properly
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/seed_production_data.py
+++ b/backend/scripts/seed_production_data.py
@@ -8,11 +8,7 @@ This script replaces all mock/demo data with production-ready seed data that can
 for testing reports, employee management, inventory tracking, and all other features.
 
 NO MOCK DATA - Only realistic data a Mexican restaurant would actually have.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import asyncio
 import sys

--- a/backend/scripts/setup_subscription_plans.py
+++ b/backend/scripts/setup_subscription_plans.py
@@ -7,10 +7,7 @@ to restaurants when they sign up for the platform.
 
 Run this script after running the database migration:
 python backend/scripts/setup_subscription_plans.py
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/scripts/test_replica_monitoring.py
+++ b/backend/scripts/test_replica_monitoring.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 """
 Test script for replica monitoring system.
-<<<<<<< HEAD
-=======
 Verifies that instance tracking and monitoring endpoints are working correctly.
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/seed_chucho_menu.py
+++ b/backend/seed_chucho_menu.py
@@ -2,10 +2,7 @@
 """
 Seed Chucho Restaurant Menu Data
 Seeds the Chucho restaurant menu data into the production database
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/seed_menu_api.py
+++ b/backend/seed_menu_api.py
@@ -14,10 +14,7 @@ Environment Variables:
     API_BASE_URL - API endpoint (defaults to production)
     AUTH_EMAIL - User email for authentication (required)
     AUTH_PASSWORD - User password for authentication (required)
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/setup_chucho_restaurant.py
+++ b/backend/setup_chucho_restaurant.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 """
 Setup Chucho Restaurant with correct name and menu
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import os
 from sqlalchemy import create_engine, text

--- a/backend/setup_database.py
+++ b/backend/setup_database.py
@@ -2,10 +2,7 @@
 """
 Database Setup Script for Fynlo POS
 Automatically sets up PostgreSQL database with proper schema and sample data
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/simple_main.py
+++ b/backend/simple_main.py
@@ -1,10 +1,7 @@
 """
 Simplified Fynlo POS Backend for debugging DigitalOcean deployment
 Minimal version to isolate the health check issue
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/start.py
+++ b/backend/start.py
@@ -2,10 +2,7 @@
 """
 Minimal startup script for DigitalOcean deployment
 Uses minimal app without external dependencies
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_analytics_api_enhancement.py
+++ b/backend/test_analytics_api_enhancement.py
@@ -2,10 +2,7 @@
 """
 Test script for Analytics API Enhancement Implementation
 Tests real-time dashboard metrics optimized for mobile consumption
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_api_alignment.py
+++ b/backend/test_api_alignment.py
@@ -2,10 +2,7 @@
 """
 API Alignment Test Script
 Tests the newly implemented endpoints to ensure frontend compatibility
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_auth.py
+++ b/backend/test_auth.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Test authentication endpoint with a sample Supabase token
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_auth_flow.py
+++ b/backend/test_auth_flow.py
@@ -2,10 +2,7 @@
 """
 Test Authentication Flow for Fynlo POS
 This script tests the complete authentication flow to identify issues
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_authentication_integration.py
+++ b/backend/test_authentication_integration.py
@@ -2,10 +2,7 @@
 """
 Authentication Integration Testing for Fynlo POS
 Comprehensive end-to-end testing of JWT authentication flow
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_authentication_security.py
+++ b/backend/test_authentication_security.py
@@ -2,10 +2,7 @@
 """
 Authentication Security Testing for Fynlo POS
 Tests security aspects of the authentication system
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_backend_functionality.py
+++ b/backend/test_backend_functionality.py
@@ -2,10 +2,7 @@
 """
 Backend Functionality Test Script
 Tests core functionality without requiring external dependencies
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_cors_parsing.py
+++ b/backend/test_cors_parsing.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Test CORS parsing directly
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_database_functionality.py
+++ b/backend/test_database_functionality.py
@@ -2,10 +2,7 @@
 """
 Database Functionality Test Suite for Fynlo POS
 Tests all database operations and API endpoints after setup
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_decimal_precision.py
+++ b/backend/test_decimal_precision.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 """
 Test script for Financial Data DECIMAL Precision verification
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import asyncio
 import sys

--- a/backend/test_error_handling.py
+++ b/backend/test_error_handling.py
@@ -2,10 +2,7 @@
 """
 Test script for Enhanced Error Handling
 Tests comprehensive error handling and validation for iOS integration
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_file_upload.py
+++ b/backend/test_file_upload.py
@@ -2,10 +2,7 @@
 """
 Test script for File Upload System
 Tests base64 image upload functionality for iOS integration
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_file_upload_endpoints.py
+++ b/backend/test_file_upload_endpoints.py
@@ -2,10 +2,7 @@
 """
 File Upload API Endpoints Testing for Fynlo POS
 Tests the actual API endpoints with real HTTP requests
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_file_upload_system.py
+++ b/backend/test_file_upload_system.py
@@ -2,10 +2,7 @@
 """
 File Upload System Testing and Validation for Fynlo POS
 Tests all file upload functionality and dependency resolution
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_foreign_key_constraints.py
+++ b/backend/test_foreign_key_constraints.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 """
 Test script for Foreign Key Constraints verification
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import asyncio
 import sys

--- a/backend/test_frontend_auth_integration.py
+++ b/backend/test_frontend_auth_integration.py
@@ -2,10 +2,7 @@
 """
 Frontend-Backend Authentication Integration Testing for Fynlo POS
 Tests authentication flow as would be used by the iOS frontend
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_mobile_compatibility.py
+++ b/backend/test_mobile_compatibility.py
@@ -2,10 +2,7 @@
 """
 Test script for Mobile API Compatibility
 Tests Odoo-style endpoints and mobile optimization features
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_offline_sync_endpoints.py
+++ b/backend/test_offline_sync_endpoints.py
@@ -2,10 +2,7 @@
 """
 Test script for Offline Sync Endpoints Implementation
 Tests batch upload, conflict resolution, and offline synchronization
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_platform_features.py
+++ b/backend/test_platform_features.py
@@ -2,10 +2,7 @@
 """
 Test script for Multi-Tenant Platform Features
 Tests platform owner dashboard and multi-restaurant management
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_prod_auth.py
+++ b/backend/test_prod_auth.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Test production authentication endpoint
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_push_notification_service.py
+++ b/backend/test_push_notification_service.py
@@ -2,10 +2,7 @@
 """
 Test script for Push Notification Service Implementation
 Tests APNs integration, device registration, and notification sending
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_server.py
+++ b/backend/test_server.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Simple test server to diagnose network connectivity issues
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_server_startup.py
+++ b/backend/test_server_startup.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Test server startup and basic API endpoints
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_settings_load.py
+++ b/backend/test_settings_load.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Test settings loading order
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_setup.py
+++ b/backend/test_setup.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Quick test script to verify backend setup and dependencies
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_standardized_responses.py
+++ b/backend/test_standardized_responses.py
@@ -1,10 +1,7 @@
 """
 Test script to verify standardized API responses
 Run this to validate the new response format works correctly
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_supabase_auth.py
+++ b/backend/test_supabase_auth.py
@@ -1,10 +1,7 @@
 """
 Test script for Supabase authentication integration
 Run this after setting up your .env file with Supabase credentials
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_transaction_management.py
+++ b/backend/test_transaction_management.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Test script for Database Transaction Management implementation
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/test_websocket_implementation.py
+++ b/backend/test_websocket_implementation.py
@@ -2,10 +2,7 @@
 """
 Test script for WebSocket Real-time Events Implementation
 Tests WebSocket connections, message broadcasting, and event handling
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_auth_uuid_consistency.py
+++ b/backend/tests/test_auth_uuid_consistency.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """
 Test script to verify UUID type consistency for Supabase authentication
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_cache_service.py
+++ b/backend/tests/test_cache_service.py
@@ -1,9 +1,6 @@
 """
 Test suite for CacheService and caching functionality
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_cache_warmer.py
+++ b/backend/tests/test_cache_warmer.py
@@ -1,9 +1,6 @@
 """
 Test suite for CacheWarmer functionality
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_cached_endpoints.py
+++ b/backend/tests/test_cached_endpoints.py
@@ -1,9 +1,6 @@
 """
 Integration tests for cached endpoints
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_correct_multitenant_isolation.py
+++ b/backend/tests/test_correct_multitenant_isolation.py
@@ -2,10 +2,7 @@
 Correct Multi-tenant Isolation Test Suite
 Platform owners (Arno, Ryan) have full access - this is by design
 The vulnerability is between restaurants, not with platform owners
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_critical_multitenant_isolation.py
+++ b/backend/tests/test_critical_multitenant_isolation.py
@@ -2,10 +2,7 @@
 Critical Multi-tenant Isolation Test Suite for Issue #361
 Tests to verify complete data isolation between restaurants
 Written BEFORE implementing fixes to ensure we catch any vulnerabilities
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_error_handling_security.py
+++ b/backend/tests/test_error_handling_security.py
@@ -1,10 +1,7 @@
 """
 Test suite for error handling security
 Ensures no sensitive information is exposed in production errors
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_fynlo_exception_migration.py
+++ b/backend/tests/test_fynlo_exception_migration.py
@@ -3,10 +3,7 @@ Test HTTPException to FynloException migration
 
 This test module verifies that all core security modules properly use
 FynloException instead of HTTPException.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -717,7 +717,4 @@ def test_{function_name}_edge_cases():
     # - Concurrent access
     # - Permission edge cases
     pass
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)

--- a/backend/tests/test_multitenant_api_isolation.py
+++ b/backend/tests/test_multitenant_api_isolation.py
@@ -1,10 +1,7 @@
 """
 API-level Multi-tenant Isolation Tests
 Tests actual API endpoints for cross-tenant access vulnerabilities
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_multitenant_isolation.py
+++ b/backend/tests/test_multitenant_isolation.py
@@ -1,10 +1,7 @@
 """
 Multi-tenant Isolation Test Suite for Fynlo POS
 Tests data isolation between restaurants and prevents cross-tenant access
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_patterns_guide.py
+++ b/backend/tests/test_patterns_guide.py
@@ -1397,11 +1397,7 @@ directory = htmlcov
 
 [xml]
 output = coverage.xml
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 # ============================================================================
 # PYTEST CONFIGURATION
@@ -1435,11 +1431,7 @@ markers =
     performance: marks performance tests
     
 asyncio_mode = auto
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 # ============================================================================
 # ADVANCED TESTING PATTERNS
@@ -1696,8 +1688,4 @@ coverage report
 
 # Show missing lines for specific file
 coverage report -m app/services/order_service.py
-<<<<<<< HEAD
-
-=======
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 """

--- a/backend/tests/test_payment_providers.py
+++ b/backend/tests/test_payment_providers.py
@@ -1,9 +1,6 @@
 """
 Comprehensive tests for payment providers
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_provider_integration.py
+++ b/backend/tests/test_provider_integration.py
@@ -1,10 +1,7 @@
 """
 Provider Integration Tests
 Real integration tests for payment providers (requires test credentials)
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_redis_fallback_security.py
+++ b/backend/tests/test_redis_fallback_security.py
@@ -1,9 +1,6 @@
 """
 Tests for Redis fallback security - ensures fail-closed behavior
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_rls_bug_fixes.py
+++ b/backend/tests/test_rls_bug_fixes.py
@@ -1,10 +1,7 @@
 """
 Comprehensive tests for RLS bug fixes
 Tests all issues identified by CursorBugBot
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_rls_bug_fixes_verification.py
+++ b/backend/tests/test_rls_bug_fixes_verification.py
@@ -1,10 +1,7 @@
 """
 Verification tests for RLS bug fixes
-<<<<<<< HEAD
-=======
 Ensures all fixes work correctly
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_rls_isolation.py
+++ b/backend/tests/test_rls_isolation.py
@@ -1,10 +1,7 @@
 """
 Tests for RLS (Row Level Security) session variable isolation
 Ensures that database connections properly isolate tenant data
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_rls_session_context.py
+++ b/backend/tests/test_rls_session_context.py
@@ -1,9 +1,6 @@
 """
 Test RLS Session Context Management
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_ryan_arnaud_platform_access.py
+++ b/backend/tests/test_ryan_arnaud_platform_access.py
@@ -1,10 +1,7 @@
 """
 Test Platform Owner Access for Ryan and Arnaud
 Ensures platform owners maintain full access while others are restricted
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_secure_payment_config.py
+++ b/backend/tests/test_secure_payment_config.py
@@ -1,10 +1,7 @@
 """
 Test suite for Secure Payment Configuration Service
 Tests encryption, storage, and retrieval of payment provider credentials
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_secure_payment_endpoints.py
+++ b/backend/tests/test_secure_payment_endpoints.py
@@ -1,10 +1,7 @@
 """
 Test suite for Secure Payment API Endpoints
 Tests authentication, rate limiting, permissions, and payment flows
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_secure_payment_processor.py
+++ b/backend/tests/test_secure_payment_processor.py
@@ -1,10 +1,7 @@
 """
 Test suite for Secure Payment Processor
 Tests payment processing, fallback logic, and audit trails
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,10 +1,7 @@
 """
 Comprehensive unit tests for the security module.
 Tests environment filtering, input validation, token encryption, and webhook security.
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_security_enhancements_pr414.py
+++ b/backend/tests/test_security_enhancements_pr414.py
@@ -1,11 +1,7 @@
 """
 Comprehensive tests for PR #414 security enhancements.
 Tests the actual implementation of security features added to the Fynlo backend.
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import pytest
 from unittest.mock import Mock, patch, AsyncMock

--- a/backend/tests/test_security_improvements.py
+++ b/backend/tests/test_security_improvements.py
@@ -4,11 +4,7 @@ Test suite for security improvements:
 - WebSocket rate limiting
 - Security monitoring
 - 2FA for platform owners
-<<<<<<< HEAD
-
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 import pytest
 import asyncio

--- a/backend/tests/test_tenant_isolation_vulnerability.py
+++ b/backend/tests/test_tenant_isolation_vulnerability.py
@@ -1,10 +1,7 @@
 """
 Demonstration of Multi-tenant Isolation Vulnerability
 This test file shows the current security issue before fixes
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_websocket_enhanced.py
+++ b/backend/tests/test_websocket_enhanced.py
@@ -1,9 +1,6 @@
 """
 Tests for enhanced WebSocket functionality including heartbeat and reconnection
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """

--- a/backend/tests/test_websocket_security.py
+++ b/backend/tests/test_websocket_security.py
@@ -1,10 +1,7 @@
 """
 WebSocket Security Test Suite for Fynlo POS
 Tests authentication, authorization, rate limiting, and multi-tenant isolation
-<<<<<<< HEAD
-=======
 """
->>>>>>> parent of af057592 (fix: docstring syntax and formatting issues across backend)
 
 
 """


### PR DESCRIPTION
## Summary
The revert PR #497 was merged but left conflict markers in 212 files, causing deployment to fail with a syntax error in config.py.

## Problem
- After merging the revert, deployment still failed with `SyntaxError: unterminated triple-quoted string literal` in config.py
- Investigation revealed 212 Python files still contained conflict markers like `<<<<<<< HEAD`
- These markers were preventing the backend from starting

## Solution
- Created a script to systematically remove all conflict markers from Python files
- Fixed 212 files by accepting the parent version (before the corruption)
- All Python files now parse correctly

## Testing
- Verified config.py parses without syntax errors
- Checked that all Python files are syntactically valid
- Backend should now start successfully

## Files Changed
212 Python files cleaned of conflict markers

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>