### PR TITLE
Fix: Syntax error in responses.py causing deployment failure

### DIFF
--- a/backend/app/core/responses.py
+++ b/backend/app/core/responses.py
@@ -3,8 +3,6 @@ Standardized API Response System for Fynlo POS
 iOS-friendly response wrapper for consistent mobile app integration
 """
 
-
-"""
 from typing import Any, Optional, Dict, List
 from datetime import datetime
 from pydantic import BaseModel


### PR DESCRIPTION
## 🚨 Critical Deployment Fix #2

This fixes another syntax error that's preventing deployment, this time in `responses.py`.

## The Problem
- PR #502 fixed the syntax error in `exceptions.py` 
- But there was another syntax error in `responses.py` that wasn't caught
- Line 7 had a stray opening triple quote `"""` that was never closed
- This caused Python to treat all the import statements as part of a docstring

## The Fix
- Removed the orphaned triple quote on line 7
- File now compiles successfully

## Verification
```bash
$ python3 -m py_compile app/core/responses.py
# No errors - file is syntactically valid
```

## Next Steps
Once merged, the deployment should finally succeed. The syntax checks added in PR #502 will prevent these issues in future commits, but they can't catch files that are already in the repo.

## Recommendation
After this deploys, we should run the new `check_syntax.sh` script on ALL Python files to ensure there are no more hidden syntax errors:

```bash
cd backend
./check_syntax.sh
```