### PR TITLE
Fix: Auto-run database migrations on app startup

### DIFF
--- a/backend/app/core/run_migrations.py
+++ b/backend/app/core/run_migrations.py
@@ -1,0 +1,37 @@
+"""
+Run Alembic migrations on app startup
+"""
+import logging
+from alembic import command
+from alembic.config import Config
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def run_migrations():
+    """Run pending Alembic migrations"""
+    try:
+        # Get the alembic.ini path relative to the backend directory
+        backend_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        alembic_ini_path = os.path.join(backend_dir, "alembic.ini")
+        
+        if not os.path.exists(alembic_ini_path):
+            logger.warning(f"alembic.ini not found at {alembic_ini_path}")
+            return
+        
+        logger.info("Running database migrations...")
+        
+        # Create Alembic configuration
+        alembic_cfg = Config(alembic_ini_path)
+        
+        # Run migrations
+        command.upgrade(alembic_cfg, "head")
+        
+        logger.info("Database migrations completed successfully")
+        
+    except Exception as e:
+        # Log error but don't crash the app
+        logger.error(f"Error running migrations: {str(e)}")
+        # In production, we might want to alert but continue
+        # The app might still work with existing schema

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,6 +60,11 @@ async def lifespan(app: FastAPI):
     try:
         from app.core.database import init_db
         from app.core.redis_client import init_redis
+        from app.core.run_migrations import run_migrations
+
+        # Run migrations first (before init_db)
+        logger.info("Running database migrations...")
+        run_migrations()
 
         logger.info("Initializing database...")
         await init_db()


### PR DESCRIPTION
## Problem
Database migrations are not running automatically on deployment, causing authentication failures when schema doesn't match code.

## Solution  
- Added `run_migrations.py` module that runs Alembic migrations
- Migrations now run automatically on app startup (before database initialization)
- Errors are logged but don't crash the app
- Ensures database schema is always synchronized with deployed code

## Impact
- Fixes authentication issues caused by missing database columns
- Prevents future schema mismatches
- No manual migration steps needed after deployment

## Testing
- Migrations run safely on every startup
- If migrations already applied, Alembic skips them
- Errors are logged but app continues to start

This will ensure the missing `current_restaurant_id` and `last_restaurant_switch` columns are created automatically.