### PR TITLE
WS 403 fix + Employee API path; clarify SumUp Tap-to-Pay

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/services/DatabaseService.ts
+++ b/CashApp-iOS/CashAppPOS/src/services/DatabaseService.ts
@@ -499,11 +499,11 @@ class DatabaseService {
       });
 
       // Enhanced response validation and parsing
-      logger.info('📦 API Response structure:', { 
+      logger.info('📦 API Response structure:', {
         hasData: !!response.data,
         hasSuccess: !!response.success,
         dataType: Array.isArray(response.data) ? 'array' : typeof response.data,
-        dataLength: Array.isArray(response.data) ? response.data.length : 0
+        dataLength: Array.isArray(response.data) ? response.data.length : 0,
       });
 
       if (response.success && response.data && Array.isArray(response.data)) {
@@ -517,12 +517,12 @@ class DatabaseService {
           } else if (typeof item.price === 'number') {
             price = item.price;
           }
-          
+
           return {
             ...item,
             price,
             id: String(item.id), // Ensure ID is string
-            available: item.available !== undefined ? item.available : true
+            available: item.available !== undefined ? item.available : true,
           };
         });
 
@@ -535,7 +535,7 @@ class DatabaseService {
           this.menuCache.itemsTimestamp = Date.now();
           return transformedData;
         }
-        
+
         // Cache the properly typed items
         this.menuCache.items = menuItems;
         this.menuCache.itemsTimestamp = Date.now();
@@ -1106,7 +1106,7 @@ class DatabaseService {
 
   async getEmployees(): Promise<any[]> {
     try {
-      const response = await this.apiRequest('/api/v1/employees', {
+      const response = await this.apiRequest('/api/v1/employees/', {
         method: 'GET',
       });
 

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -18,6 +18,7 @@ from app.api.v1.endpoints import (
     platform_settings_public,
     payment_configurations,
     websocket,
+    websocket_enhanced,
     sync,
     notifications,
     menu,
@@ -45,6 +46,11 @@ from app.api.v1.platform import platform_router
 # Specific routes can override this with their own @limiter.limit decorator.
 # api_router = APIRouter(dependencies=[Depends(limiter.limit(DEFAULT_RATE))])
 api_router = APIRouter()
+
+# Mount enhanced websocket FIRST so it handles /ws/{connection_type}/{restaurant_id}
+api_router.include_router(
+    websocket_enhanced.router, prefix="/websocket", tags=["websocket_enhanced"]
+)
 
 
 # Include all endpoint routers


### PR DESCRIPTION
## Summary
- Switch backend to enhanced WebSocket router so RN client can authenticate via first message; stops 403 on connect
- Fix iOS employee API path to include trailing slash: /api/v1/employees/
- Add PR notes clarifying SumUp Tap-to-Pay requires Apple entitlements (external) — no code change inside app

## Context
- Fixes recurring `403: Connection refused` during WebSocket connect. Root cause was server mounting legacy router that required query params which RN bundle sometimes strips. Enhanced router supports message-based auth.
- Employee endpoints on backend expect trailing slash; client was missing it, causing potential 404/405 depending on proxy.

## Deployment / Testing
1) Deploy backend with this router change
2) Rebuild iOS bundle after deploy to ensure latest dual-auth WS client:
   - In `CashApp-iOS/CashAppPOS`:
     ```bash
     npx metro build index.js --platform ios --dev false --out ios/main.jsbundle
     mv ios/main.jsbundle.js ios/main.jsbundle
     cp ios/main.jsbundle ios/CashAppPOS/main.jsbundle
     ```
3) Log in, verify WebSocket connects (EnhancedWebSocketService logs "authenticated")
4) Verify GET /public/menu/items returns data (server logs improved separately in follow-up)
5) Verify employee list loads without 404/405

## Notes on SumUp Tap-to-Pay
- The app correctly hides Tap-to-Pay modal because required Apple entitlements are not present in `CashAppPOS-Development.entitlements`. Enabling this is an Apple provisioning/profile process outside code; we can document and proceed once entitlements are approved.

## Risk
- Low: Router swap is scoped to WebSocket endpoint; HTTP API unchanged. iOS path change is additive (trailing slash).