### PR TITLE
Fix: Revert to pre-PR559 state with critical fixes

### DIFF
--- a/CashApp-iOS/CashAppPOS/index.js
+++ b/CashApp-iOS/CashAppPOS/index.js
@@ -1,0 +1,9 @@
+/**
+ * @format
+ */
+
+import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/CashApp-iOS/CashAppPOS/src/components/layout/Container.tsx
+++ b/CashApp-iOS/CashAppPOS/src/components/layout/Container.tsx
@@ -6,7 +6,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../../design-system/ThemeProvider';
 import { useResponsive, useResponsiveValue } from '../../hooks/useResponsive';
 
-import type { spacing } from '../../design-system/theme';
+import { spacing } from '../../design-system/theme';
 
 // Container variants
 export type ContainerVariant = 'fluid' | 'constrained';

--- a/CashApp-iOS/CashAppPOS/src/components/layout/ResponsiveGrid.tsx
+++ b/CashApp-iOS/CashAppPOS/src/components/layout/ResponsiveGrid.tsx
@@ -6,7 +6,8 @@ import { View, StyleSheet } from 'react-native';
 import { useTheme } from '../../design-system/ThemeProvider';
 import { useResponsiveColumns, useResponsiveSpacing } from '../../hooks/useResponsive';
 
-import type { Theme, spacing } from '../../design-system/theme';
+import type { Theme } from '../../design-system/theme';
+import { spacing } from '../../design-system/theme';
 
 // Grid props interface
 export interface ResponsiveGridProps {

--- a/CashApp-iOS/CashAppPOS/src/navigation/SettingsNavigator.tsx
+++ b/CashApp-iOS/CashAppPOS/src/navigation/SettingsNavigator.tsx
@@ -33,7 +33,6 @@ import SettingsScreen from '../screens/settings/SettingsScreen';
 
 // Import Hardware screens
 import AccessibilityScreen from '../screens/settings/user/AccessibilityScreen';
-import AccessibilityScreen from '../screens/settings/user/AccessibilityScreen';
 import LocalizationScreen from '../screens/settings/user/LocalizationScreen';
 import NotificationSettingsScreen from '../screens/settings/user/NotificationSettingsScreen';
 import ThemeOptionsScreen from '../screens/settings/user/ThemeOptionsScreen';


### PR DESCRIPTION
## What
- Reverted codebase to commit c429888f (the last known working state before ChatGPT's PR #559)
- Applied only the essential fixes needed to make the app work:
  - Added missing index.js for React Native app registration
  - Fixed type-only imports causing 'theme' undefined errors
  - Removed duplicate AccessibilityScreen import

## Why
- PR #559 introduced breaking changes that made the iOS app unable to load
- Multiple attempts to fix the issues incrementally were unsuccessful
- Reverting to a known working state and applying minimal fixes is the safest approach

## Testing
1. Clean Xcode DerivedData
2. Build and run the iOS app
3. The app should load without errors

## Note
The bundle still needs to be rebuilt once the @fynlo/shared module issue is resolved.

🤖 Generated with Claude Code