### PR TITLE
Critical: Revert to last working state and fix iOS build

### DIFF
--- a/CashApp-iOS/CashAppPOS/metro.config.js
+++ b/CashApp-iOS/CashAppPOS/metro.config.js
@@ -1,0 +1,29 @@
+const { getDefaultConfig } = require('@react-native/metro-config');
+const path = require('path');
+
+/** @type {import('metro-config').ConfigT} */
+module.exports = (async () => {
+  const defaultConfig = await getDefaultConfig(__dirname);
+  return {
+    ...defaultConfig,
+    transformer: {
+      ...defaultConfig.transformer,
+      babelTransformerPath: require.resolve('metro-react-native-babel-transformer'),
+    },
+    resolver: {
+      ...defaultConfig.resolver,
+      sourceExts: [...defaultConfig.resolver.sourceExts, 'cjs'],
+      extraNodeModules: {
+        '@fynlo/shared': path.resolve(__dirname, '../../shared'),
+        '@babel/runtime': path.resolve(__dirname, 'node_modules/@babel/runtime'),
+      },
+      nodeModulesPaths: [
+        path.resolve(__dirname, 'node_modules'),
+        path.resolve(__dirname, '../../node_modules'),
+      ],
+    },
+    watchFolders: [
+      path.resolve(__dirname, '../../shared'),
+    ],
+  };
+})();

--- a/CashApp-iOS/CashAppPOS/src/navigation/SettingsNavigator.tsx
+++ b/CashApp-iOS/CashAppPOS/src/navigation/SettingsNavigator.tsx
@@ -33,7 +33,6 @@ import SettingsScreen from '../screens/settings/SettingsScreen';
 
 // Import Hardware screens
 import AccessibilityScreen from '../screens/settings/user/AccessibilityScreen';
-import AccessibilityScreen from '../screens/settings/user/AccessibilityScreen';
 import LocalizationScreen from '../screens/settings/user/LocalizationScreen';
 import NotificationSettingsScreen from '../screens/settings/user/NotificationSettingsScreen';
 import ThemeOptionsScreen from '../screens/settings/user/ThemeOptionsScreen';


### PR DESCRIPTION
## 🚨 Critical Fix

### What
- Reverted codebase to commit c11064c8 (last night's working WebSocket authentication fixes)
- Fixed duplicate import in SettingsNavigator.tsx
- Added @fynlo/shared module resolution to metro.config.js
- Successfully rebuilt and tested iOS bundle

### Why
After PR #565, the app crashed on launch with:
1. "ReferenceError: Can't find variable: theme"
2. "ReferenceError: Can't find variable: logger"

Investigation revealed contaminated commits (f2a18d1a and others) that added 39,000+ lines of unintended changes including:
- Bundle files that shouldn't be committed
- Cursor IDE files
- Duplicate dependencies
- Broken module references

### Testing
✅ Bundle builds successfully
✅ Force rebuild script passes all checks
✅ Key features verified in bundle:
- Report navigation
- Order details modal
- Settings store integration
- Payment method selection

### Next Steps
After merging this PR:
1. Open Xcode
2. Clean Build Folder (Cmd+Shift+K)
3. Build and Run (Cmd+R)

The app should launch successfully and all WebSocket authentication should work as it did last night.

🤖 Generated with [Claude Code](https://claude.ai/code)