### PR TITLE
Fix: iOS bundle registration error - app not launching in Xcode

### DIFF
--- a/CashApp-iOS/CashAppPOS/scripts/fix-ios-build.sh
+++ b/CashApp-iOS/CashAppPOS/scripts/fix-ios-build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Fix iOS Build Script
+# This script resolves the "CashAppPOS has not been registered" error
+
+echo "🔧 Starting iOS Build Fix..."
+
+# Navigate to project root
+cd "$(dirname "$0")/.."
+
+echo "📍 Current directory: $(pwd)"
+
+# Clean build artifacts
+echo "🧹 Cleaning build artifacts..."
+cd ios
+rm -rf build/
+rm -rf ~/Library/Developer/Xcode/DerivedData/CashAppPOS-*
+cd ..
+
+# Clear watchman cache
+echo "🔄 Clearing watchman cache..."
+watchman watch-del-all 2>/dev/null || true
+
+# Rebuild the bundle
+echo "📦 Building fresh JavaScript bundle..."
+npx react-native bundle \
+  --entry-file index.js \
+  --platform ios \
+  --dev false \
+  --bundle-output ios/main.jsbundle \
+  --assets-dest ios \
+  --reset-cache
+
+# Copy bundle to app directory
+echo "📋 Copying bundle to app directory..."
+cp ios/main.jsbundle ios/CashAppPOS/main.jsbundle
+
+# Reinstall pods
+echo "🔗 Reinstalling CocoaPods dependencies..."
+cd ios
+pod install
+cd ..
+
+echo "✅ iOS Build Fix Complete!"
+echo ""
+echo "📱 Next steps in Xcode:"
+echo "1. Open ios/CashAppPOS.xcworkspace"
+echo "2. Product → Clean Build Folder (⇧⌘K)"
+echo "3. Product → Build (⌘B)"
+echo "4. Product → Run (⌘R)"


### PR DESCRIPTION
## What
- Added script to fix iOS build issues when app fails to register properly
- Script automates the process of cleaning and rebuilding the JavaScript bundle

## Why
The app was failing to launch in Xcode with these errors:
- `Invariant Violation: "CashAppPOS" has not been registered`
- `ReferenceError: Can't find variable: theme`
- Connection refused errors trying to connect to Metro bundler

These errors occur when:
1. The JavaScript bundle is stale or corrupted
2. Xcode build artifacts are cached incorrectly
3. The app tries to connect to Metro instead of using the bundled JS

## Solution
Created `scripts/fix-ios-build.sh` that:
1. Cleans all Xcode build artifacts and DerivedData
2. Clears watchman cache to avoid stale file watching
3. Rebuilds the JavaScript bundle with `--reset-cache` flag
4. Copies bundle to the correct location for Xcode
5. Reinstalls CocoaPods dependencies

## Testing
To use the fix:
```bash
cd CashApp-iOS/CashAppPOS
./scripts/fix-ios-build.sh
```

Then in Xcode:
1. Product → Clean Build Folder (⇧⌘K)
2. Product → Build (⌘B)
3. Product → Run (⌘R)

## Notes
- The AppDelegate.swift is already configured to use bundled JS (not Metro)
- This script ensures a fresh, clean build environment
- Bundle files are gitignored (as they should be) and rebuilt as needed

🤖 Generated with [Claude Code](https://claude.ai/code)