### PR TITLE
Fix: Add missing index.js entry point file

### DIFF
--- a/CashApp-iOS/CashAppPOS/index.js
+++ b/CashApp-iOS/CashAppPOS/index.js
@@ -1,0 +1,9 @@
+/**
+ * @format
+ */
+
+import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
## What
- Added missing `index.js` file that was causing app registration errors
- This is the standard React Native entry point that registers the app component

## Why
The app was failing to launch with:
- `Invariant Violation: "CashAppPOS" has not been registered`
- Bundle build failures: `The resource index.js was not found`

## Root Cause
The `index.js` file was missing from the project root. This file is essential as it:
1. Imports the main App component
2. Registers it with AppRegistry
3. Serves as the entry point for the React Native bundle

## Solution
Created `index.js` with the standard React Native registration code:
```javascript
import { AppRegistry } from 'react-native';
import App from './App';
import { name as appName } from './app.json';

AppRegistry.registerComponent(appName, () => App);
```

## Testing
After adding this file:
1. Bundle builds successfully: `npx react-native bundle --platform ios`
2. App launches in simulator without registration errors
3. Verified app is running with PID 15212

## Verification
```bash
# Bundle builds without errors
npx react-native bundle --entry-file index.js --platform ios --dev false --bundle-output ios/main.jsbundle

# App launches successfully
xcrun simctl launch com.fynlo.cashappposlucid
```

🤖 Generated with [Claude Code](https://claude.ai/code)