### PR TITLE
fix: Activate Tap to Pay entitlement for physical device testing

### DIFF
--- a/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
+++ b/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
@@ -2,13 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- IMPORTANT: This Tap to Pay entitlement requires Apple approval -->
-	<!-- The merchant identifier below is a placeholder and must be replaced with Apple's provided value -->
-	<!-- Without the correct Apple-provided identifier, Tap to Pay will not function on devices -->
+	<!-- Tap to Pay on iPhone entitlement - Active for physical device testing -->
 	<key>com.apple.developer.proximity-reader.payment.acceptance</key>
 	<array>
-		<!-- TODO: Replace with actual Apple-provided merchant identifier after Tap to Pay approval -->
-		<string>merchant.com.fynlo.tapToPay</string>
+		<string>merchant.com.fynlo.pos</string>
 	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>


### PR DESCRIPTION
## What
- Updated Tap to Pay entitlement to use `merchant.com.fynlo.pos` identifier
- This matches the bundle identifier configuration with proper Apple entitlements
- Resolves provisioning profile mismatch error

## Why
- The previous placeholder value was causing provisioning profile errors
- The bundle identifier already has the Tap to Pay entitlement attached
- Needed for testing on physical iPhone devices

## Testing
1. Build the app for physical device
2. Deploy to iPhone XS or later with iOS 15.4+
3. Navigate to payment screen
4. Select Card payment method
5. SumUp modal should initialize for Tap to Pay

## Requirements
- Physical iPhone (XS or later)
- iOS 15.4 or later  
- Provisioning profile with Tap to Pay entitlement

🤖 Generated with Claude Code