### PR TITLE
fix: Correct merchant identifiers to match bundle ID

### DIFF
--- a/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
+++ b/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
@@ -2,14 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Tap to Pay on iPhone entitlement - Active for physical device testing -->
+	<!-- Tap to Pay on iPhone entitlement - Matches bundle ID com.fynlo.cashappposlucid -->
 	<key>com.apple.developer.proximity-reader.payment.acceptance</key>
 	<array>
-		<string>merchant.com.fynlo.pos</string>
+		<string>merchant.com.fynlo.cashappposlucid</string>
 	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
-		<string>merchant.com.fynlo.pos</string>
+		<string>merchant.com.fynlo.cashappposlucid</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem
The provisioning profile was showing a mismatch error in Xcode:
`Provisioning profile 'iOS Team Provisioning Profile: com.fynlo.cashappposlucid' doesn't match the entitlements file's value for the com.apple.developer.proximity-reader.payment.acceptance entitlement.`

## Root Cause
The entitlements file was using `merchant.com.fynlo.pos` but the actual bundle identifier is `com.fynlo.cashappposlucid`.

## Solution
Updated both entitlements to use the correct merchant identifier:
- ✅ `merchant.com.fynlo.cashappposlucid` (matches bundle ID)
- ❌ `merchant.com.fynlo.pos` (incorrect)

## Changes
- Updated `com.apple.developer.proximity-reader.payment.acceptance` entitlement
- Updated `com.apple.developer.in-app-payments` entitlement
- Both now use `merchant.com.fynlo.cashappposlucid`

## Testing
1. Open project in Xcode
2. Select physical device (iPhone XS or later)
3. Build and run - provisioning error should be resolved
4. Deploy to device for Tap to Pay testing

## Evidence
- Bundle ID in project: `com.fynlo.cashappposlucid`
- Apple Developer portal shows Tap to Pay entitlement enabled
- Xcode was showing provisioning profile mismatch (see screenshot in issue)

🤖 Generated with Claude Code