### PR TITLE
fix: Temporarily disable Tap to Pay entitlement to fix provisioning

### DIFF
--- a/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
+++ b/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
@@ -2,11 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Tap to Pay on iPhone entitlement - Matches bundle ID com.fynlo.cashappposlucid -->
+	<!-- 
+	Tap to Pay on iPhone entitlement temporarily disabled
+	Apple's automatic provisioning is failing with this entitlement.
+	This needs to be enabled with the exact value Apple provides after Tap to Pay approval.
+	
 	<key>com.apple.developer.proximity-reader.payment.acceptance</key>
 	<array>
-		<string>merchant.com.fynlo.cashappposlucid</string>
+		<string>NEEDS_APPLE_PROVIDED_VALUE</string>
 	</array>
+	-->
+	
+	<!-- Apple Pay / In-App Payments entitlement -->
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.com.fynlo.cashappposlucid</string>


### PR DESCRIPTION
## Problem
Xcode automatic signing is failing with the error:
`Provisioning profile 'iOS Team Provisioning Profile: com.fynlo.cashappposlucid' doesn't match the entitlements file's value for the com.apple.developer.proximity-reader.payment.acceptance entitlement.`

## Investigation
- The bundle ID is correct: `com.fynlo.cashappposlucid`
- The merchant ID matches: `merchant.com.fynlo.cashappposlucid`
- Apple Pay entitlement works fine
- The issue is specifically with the Tap to Pay entitlement

## Root Cause
The Tap to Pay on iPhone entitlement (`com.apple.developer.proximity-reader.payment.acceptance`) requires:
1. Special approval from Apple
2. A specific entitlement value that Apple provides
3. Manual provisioning profile configuration

The automatic provisioning is failing because it cannot generate a profile with this special entitlement.

## Solution
Temporarily comment out the Tap to Pay entitlement while keeping Apple Pay active. This allows:
- ✅ App builds and deploys successfully
- ✅ Apple Pay functionality remains available
- ✅ Development can continue
- ⏸️ Tap to Pay will be re-enabled once we have the correct Apple-provided configuration

## Next Steps
1. Contact Apple Developer Support about Tap to Pay entitlement configuration
2. Get the exact entitlement value required
3. Configure manual provisioning profile if needed
4. Re-enable the entitlement with correct values

## Testing
1. Build should now succeed in Xcode
2. Deploy to physical device works
3. Apple Pay functionality remains available
4. SumUp integration will show fallback options for now

🤖 Generated with Claude Code