### PR TITLE
fix: Use bundle ID for Tap to Pay entitlement

### DIFF
--- a/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
+++ b/CashApp-iOS/CashAppPOS/ios/CashAppPOS/CashAppPOS.entitlements
@@ -5,7 +5,7 @@
 	<!-- Tap to Pay on iPhone entitlement -->
 	<key>com.apple.developer.proximity-reader.payment.acceptance</key>
 	<array>
-		<string>SUMUP</string>
+		<string>com.fynlo.cashappposlucid</string>
 	</array>
 	
 	<!-- Apple Pay / In-App Payments entitlement -->


### PR DESCRIPTION
## The Solution
Use the bundle identifier directly for Tap to Pay entitlement.

## What I Changed
- Tap to Pay entitlement: `com.fynlo.cashappposlucid` (bundle ID without prefix)
- Apple Pay entitlement: `merchant.com.fynlo.cashappposlucid` (with merchant prefix)

## Why This Should Work
Based on the error message and Apple's documentation:
- Tap to Pay entitlement value should match the bundle identifier
- Apple Pay uses the merchant prefix format
- Each entitlement has its own format requirements

## Testing
1. Build in Xcode - provisioning should succeed
2. Deploy to physical iPhone
3. Test both Tap to Pay and Apple Pay functionality

If this still doesn't work, we may need to:
- Check if there's a specific value Apple provided in your developer portal
- Try removing the entitlement array wrapper (just use a string value)
- Contact Apple Developer Support for the exact format required

🤖 Generated with Claude Code