### PR TITLE
PR#4: Native SumUp Module Bridge Implementation

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/components/payment/NativeSumUpPayment.tsx
+++ b/CashApp-iOS/CashAppPOS/src/components/payment/NativeSumUpPayment.tsx
@@ -263,7 +263,27 @@ const NativeSumUpPayment: React.FC<NativeSumUpPaymentProps> = ({
         {Platform.OS === 'ios' && !isLoggedIn && (
           <TouchableOpacity
             style={[styles.loginHint, { backgroundColor: theme.colors.info[100] }]}
-            onPress={() => NativeSumUpService.presentLogin()}
+            onPress={async () => {
+              try {
+                logger.info('🔐 User tapped login hint');
+                const loginSuccess = await NativeSumUpService.presentLogin();
+                if (loginSuccess) {
+                  logger.info('✅ Login successful from hint');
+                  setIsLoggedIn(true);
+                  // Retry payment initialization after successful login
+                  initializePayment();
+                } else {
+                  logger.warn('⚠️ Login was cancelled or failed');
+                }
+              } catch (error) {
+                logger.error('❌ Login error from hint:', error);
+                Alert.alert(
+                  'Login Failed',
+                  'Unable to complete login. Please try again.',
+                  [{ text: 'OK' }]
+                );
+              }
+            }}
           >
             <Icon name="info" size={20} color={theme.colors.info[700]} />
             <Text style={[styles.loginHintText, { color: theme.colors.info[700] }]}>

--- a/CashApp-iOS/CashAppPOS/src/components/payment/NativeSumUpPayment.tsx
+++ b/CashApp-iOS/CashAppPOS/src/components/payment/NativeSumUpPayment.tsx
@@ -1,0 +1,368 @@
+/**
+ * NativeSumUpPayment - Direct native SumUp SDK implementation
+ * 
+ * This component bypasses the problematic sumup-react-native-alpha package
+ * and uses the native iOS SumUp SDK directly through our bridge.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Alert,
+  ActivityIndicator,
+  TouchableOpacity,
+  Platform,
+} from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+
+import { useTheme } from '../../design-system/ThemeProvider';
+import NativeSumUpService from '../../services/NativeSumUpService';
+import sumUpConfigService from '../../services/SumUpConfigService';
+import { logger } from '../../utils/logger';
+
+interface NativeSumUpPaymentProps {
+  amount: number;
+  currency: string;
+  title: string;
+  visible: boolean;
+  onPaymentComplete: (success: boolean, transactionCode?: string, error?: string) => void;
+  onPaymentCancel: () => void;
+  useTapToPay?: boolean;
+}
+
+type PaymentStatus = 'initializing' | 'ready' | 'processing' | 'success' | 'failed' | 'cancelled';
+
+const NativeSumUpPayment: React.FC<NativeSumUpPaymentProps> = ({
+  amount,
+  currency,
+  title,
+  visible,
+  onPaymentComplete,
+  onPaymentCancel,
+  useTapToPay = true,
+}) => {
+  const { theme } = useTheme();
+  const [paymentStatus, setPaymentStatus] = useState<PaymentStatus>('initializing');
+  const [statusMessage, setStatusMessage] = useState('Initializing payment...');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [tapToPayAvailable, setTapToPayAvailable] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      initializePayment();
+    }
+  }, [visible]);
+
+  const initializePayment = async () => {
+    try {
+      logger.info('🔧 Initializing native SumUp payment');
+      setPaymentStatus('initializing');
+      setStatusMessage('Setting up payment...');
+
+      // Check if native module is available
+      if (!NativeSumUpService.isAvailable()) {
+        throw new Error('SumUp native module not available on this device');
+      }
+
+      // Get API key from config
+      const config = sumUpConfigService.getConfig();
+      const apiKey = config.affiliateKey;
+
+      if (!apiKey) {
+        throw new Error('SumUp API key not configured');
+      }
+
+      // Setup SDK if needed
+      if (!NativeSumUpService.isSDKSetup()) {
+        logger.info('🔧 Setting up SumUp SDK');
+        await NativeSumUpService.setupSDK(apiKey);
+      }
+
+      // Check login status
+      const loggedIn = await NativeSumUpService.isLoggedIn();
+      setIsLoggedIn(loggedIn);
+
+      if (!loggedIn) {
+        logger.info('🔐 User not logged in, presenting login');
+        const loginSuccess = await NativeSumUpService.presentLogin();
+        if (!loginSuccess) {
+          throw new Error('Login failed or was cancelled');
+        }
+        setIsLoggedIn(true);
+      }
+
+      // Check Tap to Pay availability if requested
+      if (useTapToPay) {
+        const tapToPayStatus = await NativeSumUpService.checkTapToPayAvailability();
+        logger.info('📱 Tap to Pay status:', tapToPayStatus);
+        
+        if (tapToPayStatus.isAvailable && !tapToPayStatus.isActivated) {
+          logger.info('📱 Tap to Pay available but not activated, presenting activation');
+          const activationSuccess = await NativeSumUpService.presentTapToPayActivation();
+          if (activationSuccess) {
+            setTapToPayAvailable(true);
+          }
+        } else if (tapToPayStatus.isAvailable && tapToPayStatus.isActivated) {
+          setTapToPayAvailable(true);
+        }
+      }
+
+      setPaymentStatus('ready');
+      setStatusMessage('Ready to process payment');
+
+      // Automatically start payment
+      await processPayment();
+    } catch (error) {
+      logger.error('❌ Payment initialization failed:', error);
+      setPaymentStatus('failed');
+      setErrorMessage(error instanceof Error ? error.message : 'Payment initialization failed');
+      setStatusMessage('Failed to initialize payment');
+    }
+  };
+
+  const processPayment = async () => {
+    try {
+      logger.info('💳 Processing payment:', { amount, currency, title, useTapToPay });
+      setPaymentStatus('processing');
+      setStatusMessage(useTapToPay && tapToPayAvailable ? 'Tap card on phone...' : 'Processing payment...');
+
+      const result = await NativeSumUpService.performCheckout(
+        amount,
+        currency,
+        title,
+        useTapToPay && tapToPayAvailable
+      );
+
+      if (result.success) {
+        logger.info('✅ Payment successful:', result);
+        setPaymentStatus('success');
+        setStatusMessage('Payment successful!');
+        
+        // Small delay to show success state
+        setTimeout(() => {
+          onPaymentComplete(true, result.transactionCode);
+        }, 1500);
+      } else {
+        throw new Error(result.error || 'Payment failed');
+      }
+    } catch (error) {
+      logger.error('❌ Payment processing failed:', error);
+      setPaymentStatus('failed');
+      const errorMsg = error instanceof Error ? error.message : 'Payment processing failed';
+      setErrorMessage(errorMsg);
+      setStatusMessage('Payment failed');
+      
+      // Check if it was cancelled
+      if (errorMsg.toLowerCase().includes('cancel')) {
+        setPaymentStatus('cancelled');
+        setStatusMessage('Payment cancelled');
+        onPaymentCancel();
+      } else {
+        onPaymentComplete(false, undefined, errorMsg);
+      }
+    }
+  };
+
+  const handleRetry = () => {
+    setErrorMessage(null);
+    initializePayment();
+  };
+
+  const handleCancel = () => {
+    logger.info('User cancelled payment');
+    setPaymentStatus('cancelled');
+    onPaymentCancel();
+  };
+
+  const getStatusIcon = () => {
+    switch (paymentStatus) {
+      case 'success':
+        return <Icon name="check-circle" size={64} color={theme.colors.success} />;
+      case 'failed':
+        return <Icon name="error" size={64} color={theme.colors.danger[500]} />;
+      case 'cancelled':
+        return <Icon name="cancel" size={64} color={theme.colors.warning[500]} />;
+      case 'processing':
+        return <ActivityIndicator size="large" color={theme.colors.primary} />;
+      default:
+        return <Icon name="tap-and-play" size={64} color={theme.colors.primary} />;
+    }
+  };
+
+  const formatAmount = (value: number) => {
+    const symbol =
+      currency === 'GBP' ? '£' : currency === 'EUR' ? '€' : currency === 'USD' ? '$' : currency;
+    return `${symbol}${value.toFixed(2)}`;
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <View style={[styles.modal, { backgroundColor: theme.colors.surface }]}>
+        <View style={styles.header}>
+          <Text style={[styles.title, { color: theme.colors.text }]}>
+            {paymentStatus === 'processing' && useTapToPay && tapToPayAvailable
+              ? 'Tap to Pay'
+              : 'SumUp Payment'}
+          </Text>
+        </View>
+
+        <View style={styles.content}>
+          {getStatusIcon()}
+
+          <Text style={[styles.amount, { color: theme.colors.primary }]}>
+            {formatAmount(amount)}
+          </Text>
+
+          <Text style={[styles.status, { color: theme.colors.textSecondary }]}>
+            {statusMessage}
+          </Text>
+
+          {errorMessage && (
+            <Text style={[styles.error, { color: theme.colors.danger[500] }]}>
+              {errorMessage}
+            </Text>
+          )}
+
+          {paymentStatus === 'processing' && useTapToPay && tapToPayAvailable && (
+            <View style={styles.tapInstructions}>
+              <Icon name="contactless" size={48} color={theme.colors.primary} />
+              <Text style={[styles.instructionText, { color: theme.colors.textSecondary }]}>
+                Hold card near the top of your iPhone
+              </Text>
+            </View>
+          )}
+        </View>
+
+        <View style={styles.footer}>
+          {paymentStatus === 'failed' && (
+            <TouchableOpacity
+              style={[styles.button, { backgroundColor: theme.colors.primary }]}
+              onPress={handleRetry}
+            >
+              <Text style={[styles.buttonText, { color: theme.colors.background }]}>Retry</Text>
+            </TouchableOpacity>
+          )}
+
+          {(paymentStatus === 'initializing' || paymentStatus === 'ready') && (
+            <TouchableOpacity
+              style={[styles.button, styles.cancelButton, { borderColor: theme.colors.border }]}
+              onPress={handleCancel}
+            >
+              <Text style={[styles.buttonText, { color: theme.colors.text }]}>Cancel</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+
+        {Platform.OS === 'ios' && !isLoggedIn && (
+          <TouchableOpacity
+            style={[styles.loginHint, { backgroundColor: theme.colors.info[100] }]}
+            onPress={() => NativeSumUpService.presentLogin()}
+          >
+            <Icon name="info" size={20} color={theme.colors.info[700]} />
+            <Text style={[styles.loginHintText, { color: theme.colors.info[700] }]}>
+              Tap here to login to SumUp
+            </Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  modal: {
+    width: '90%',
+    maxWidth: 400,
+    borderRadius: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  header: {
+    padding: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(0, 0, 0, 0.1)',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  content: {
+    padding: 30,
+    alignItems: 'center',
+  },
+  amount: {
+    fontSize: 36,
+    fontWeight: 'bold',
+    marginTop: 20,
+    marginBottom: 10,
+  },
+  status: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginTop: 10,
+  },
+  error: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 10,
+  },
+  tapInstructions: {
+    marginTop: 20,
+    alignItems: 'center',
+  },
+  instructionText: {
+    fontSize: 14,
+    marginTop: 10,
+    textAlign: 'center',
+  },
+  footer: {
+    padding: 20,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(0, 0, 0, 0.1)',
+  },
+  button: {
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  cancelButton: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  loginHint: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    margin: 16,
+    borderRadius: 8,
+  },
+  loginHintText: {
+    fontSize: 14,
+    marginLeft: 8,
+    flex: 1,
+  },
+});
+
+export default NativeSumUpPayment;

--- a/CashApp-iOS/CashAppPOS/src/screens/payment/EnhancedPaymentScreen.tsx
+++ b/CashApp-iOS/CashAppPOS/src/screens/payment/EnhancedPaymentScreen.tsx
@@ -17,9 +17,11 @@ import Icon from 'react-native-vector-icons/MaterialIcons';
 import DecimalInput from '../../components/inputs/DecimalInput';
 import SimpleDecimalInput from '../../components/inputs/SimpleDecimalInput';
 import SimpleTextInput from '../../components/inputs/SimpleTextInput';
+import NativeSumUpPayment from '../../components/payment/NativeSumUpPayment';
 import SumUpPaymentComponent from '../../components/payment/SumUpPaymentComponent';
 import { useAuth } from '../../contexts/AuthContext';
 import ApplePayService from '../../services/ApplePayService';
+import NativeSumUpService from '../../services/NativeSumUpService';
 import OrderService from '../../services/OrderService';
 import SharedDataStore from '../../services/SharedDataStore';
 import SumUpCompatibilityService from '../../services/SumUpCompatibilityService';
@@ -117,14 +119,24 @@ const EnhancedPaymentScreen: React.FC = () => {
     return subtotal * (platformServiceCharge.rate / 100);
   };
 
-  // Check SumUp availability on mount
+  // Check SumUp availability on mount - prefer native module
   useEffect(() => {
     const checkSumUpAvailability = async () => {
       try {
-        const compatibilityService = SumUpCompatibilityService.getInstance();
-        const shouldAttempt = await compatibilityService.shouldAttemptSumUp();
-        setSumUpAvailable(shouldAttempt);
-        logger.info('🔍 SumUp availability check:', { available: shouldAttempt });
+        // First check if native module is available
+        const nativeAvailable = NativeSumUpService.isAvailable();
+        logger.info('📱 Native SumUp module available:', nativeAvailable);
+        
+        if (nativeAvailable) {
+          // Use native module
+          setSumUpAvailable(true);
+        } else {
+          // Fallback to compatibility service check
+          const compatibilityService = SumUpCompatibilityService.getInstance();
+          const shouldAttempt = await compatibilityService.shouldAttemptSumUp();
+          setSumUpAvailable(shouldAttempt);
+          logger.info('🔍 SumUp compatibility check:', { available: shouldAttempt });
+        }
       } catch (error) {
         logger.error('Failed to check SumUp availability:', error);
         setSumUpAvailable(false);
@@ -1088,8 +1100,32 @@ const EnhancedPaymentScreen: React.FC = () => {
       {/* QR Payment Modal */}
       <QRPaymentModal />
 
-      {/* SumUp Payment Component */}
-      {showSumUpModal && (
+      {/* SumUp Payment Component - Use native if available */}
+      {showSumUpModal && NativeSumUpService.isAvailable() ? (
+        <NativeSumUpPayment
+          amount={calculateGrandTotal()}
+          currency="GBP"
+          title={`Order #${Date.now()}`}
+          visible={showSumUpModal}
+          onPaymentComplete={(success, transactionCode, error) => {
+            if (success) {
+              // Process successful payment
+              logger.info('✅ Native SumUp payment successful', { transactionCode });
+              handleProcessPayment();
+            } else {
+              // Handle error
+              logger.error('❌ Native SumUp payment failed:', error);
+              Alert.alert('Payment Failed', error || 'Unable to process payment');
+            }
+            setShowSumUpModal(false);
+          }}
+          onPaymentCancel={() => {
+            logger.info('Payment cancelled by user');
+            setShowSumUpModal(false);
+          }}
+          useTapToPay={true}
+        />
+      ) : showSumUpModal ? (
         <SumUpPaymentComponent
           amount={calculateGrandTotal()}
           currency="GBP"
@@ -1111,7 +1147,7 @@ const EnhancedPaymentScreen: React.FC = () => {
             setShowSumUpModal(false);
           }}
         />
-      )}
+      ) : null}
     </View>
   );
 };

--- a/CashApp-iOS/CashAppPOS/src/services/NativeSumUpService.ts
+++ b/CashApp-iOS/CashAppPOS/src/services/NativeSumUpService.ts
@@ -1,0 +1,348 @@
+/**
+ * NativeSumUpService - Bridge to native iOS SumUp SDK
+ * 
+ * This service provides direct access to the native SumUp SDK implementation,
+ * bypassing the problematic sumup-react-native-alpha package and using the
+ * actual iOS SDK capabilities including Tap to Pay on iPhone.
+ */
+
+import { NativeModules, Platform } from 'react-native';
+import { logger } from '../utils/logger';
+
+// Type definitions for the native module
+interface SumUpTapToPayModule {
+  setupSDK(apiKey: string): Promise<{ success: boolean }>;
+  presentLogin(): Promise<{ success: boolean }>;
+  loginWithToken(token: string): Promise<{ success: boolean }>;
+  logout(): Promise<{ success: boolean }>;
+  checkTapToPayAvailability(): Promise<{ isAvailable: boolean; isActivated: boolean }>;
+  presentTapToPayActivation(): Promise<{ success: boolean }>;
+  checkout(
+    amount: number,
+    title: string,
+    currencyCode: string,
+    foreignTransactionID: string | null,
+    useTapToPay: boolean
+  ): Promise<TransactionResult>;
+  presentCheckoutPreferences(): Promise<{ success: boolean }>;
+  getCurrentMerchant(): Promise<MerchantInfo | null>;
+  isLoggedIn(): Promise<{ isLoggedIn: boolean }>;
+}
+
+interface TransactionResult {
+  success: boolean;
+  transactionCode?: string;
+  transactionInfo?: {
+    amount: number;
+    currency: string;
+    status: string;
+    paymentType?: string;
+    entryMode?: string;
+    installments?: number;
+    cardType?: string;
+    cardLastDigits?: string;
+  };
+  error?: string;
+}
+
+interface MerchantInfo {
+  merchantCode: string;
+  currencyCode: string;
+  name?: string;
+}
+
+// Get the native module
+const { SumUpTapToPayModule: NativeSumUp } = NativeModules as {
+  SumUpTapToPayModule: SumUpTapToPayModule | undefined;
+};
+
+class NativeSumUpService {
+  private static instance: NativeSumUpService;
+  private isSetup: boolean = false;
+  private apiKey: string | null = null;
+
+  private constructor() {
+    logger.info('🔧 NativeSumUpService initialized');
+  }
+
+  static getInstance(): NativeSumUpService {
+    if (!NativeSumUpService.instance) {
+      NativeSumUpService.instance = new NativeSumUpService();
+    }
+    return NativeSumUpService.instance;
+  }
+
+  /**
+   * Check if the native module is available
+   */
+  isAvailable(): boolean {
+    const available = Platform.OS === 'ios' && NativeSumUp !== undefined;
+    logger.info('📱 Native SumUp module availability:', { available, platform: Platform.OS });
+    return available;
+  }
+
+  /**
+   * Setup the SumUp SDK with API key
+   */
+  async setupSDK(apiKey: string): Promise<void> {
+    if (!this.isAvailable()) {
+      throw new Error('Native SumUp module is not available');
+    }
+
+    try {
+      logger.info('🔧 Setting up SumUp SDK with API key');
+      const result = await NativeSumUp!.setupSDK(apiKey);
+      
+      if (result.success) {
+        this.isSetup = true;
+        this.apiKey = apiKey;
+        logger.info('✅ SumUp SDK setup successful');
+      } else {
+        throw new Error('SumUp SDK setup failed');
+      }
+    } catch (error) {
+      logger.error('❌ Failed to setup SumUp SDK:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if SDK is setup
+   */
+  isSDKSetup(): boolean {
+    return this.isSetup;
+  }
+
+  /**
+   * Present login screen
+   */
+  async presentLogin(): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error('Native SumUp module is not available');
+    }
+
+    if (!this.isSetup) {
+      throw new Error('SumUp SDK not setup. Call setupSDK first.');
+    }
+
+    try {
+      logger.info('🔐 Presenting SumUp login');
+      const result = await NativeSumUp!.presentLogin();
+      logger.info('🔐 Login result:', result);
+      return result.success;
+    } catch (error) {
+      logger.error('❌ Login failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Login with token
+   */
+  async loginWithToken(token: string): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error('Native SumUp module is not available');
+    }
+
+    if (!this.isSetup) {
+      throw new Error('SumUp SDK not setup. Call setupSDK first.');
+    }
+
+    try {
+      logger.info('🔐 Logging in with token');
+      const result = await NativeSumUp!.loginWithToken(token);
+      return result.success;
+    } catch (error) {
+      logger.error('❌ Token login failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if user is logged in
+   */
+  async isLoggedIn(): Promise<boolean> {
+    if (!this.isAvailable()) {
+      return false;
+    }
+
+    try {
+      const result = await NativeSumUp!.isLoggedIn();
+      return result.isLoggedIn;
+    } catch (error) {
+      logger.error('❌ Failed to check login status:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Logout
+   */
+  async logout(): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error('Native SumUp module is not available');
+    }
+
+    try {
+      logger.info('🔐 Logging out');
+      const result = await NativeSumUp!.logout();
+      return result.success;
+    } catch (error) {
+      logger.error('❌ Logout failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check Tap to Pay availability
+   */
+  async checkTapToPayAvailability(): Promise<{ isAvailable: boolean; isActivated: boolean }> {
+    if (!this.isAvailable()) {
+      return { isAvailable: false, isActivated: false };
+    }
+
+    try {
+      logger.info('📱 Checking Tap to Pay availability');
+      const result = await NativeSumUp!.checkTapToPayAvailability();
+      logger.info('📱 Tap to Pay status:', result);
+      return result;
+    } catch (error) {
+      logger.error('❌ Failed to check Tap to Pay availability:', error);
+      return { isAvailable: false, isActivated: false };
+    }
+  }
+
+  /**
+   * Present Tap to Pay activation
+   */
+  async presentTapToPayActivation(): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error('Native SumUp module is not available');
+    }
+
+    try {
+      logger.info('📱 Presenting Tap to Pay activation');
+      const result = await NativeSumUp!.presentTapToPayActivation();
+      return result.success;
+    } catch (error) {
+      logger.error('❌ Tap to Pay activation failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Perform checkout (card reader or Tap to Pay)
+   */
+  async performCheckout(
+    amount: number,
+    currency: string = 'GBP',
+    title: string = 'Payment',
+    useTapToPay: boolean = false,
+    foreignTransactionID?: string
+  ): Promise<TransactionResult> {
+    if (!this.isAvailable()) {
+      throw new Error('Native SumUp module is not available');
+    }
+
+    if (!this.isSetup) {
+      throw new Error('SumUp SDK not setup. Call setupSDK first.');
+    }
+
+    try {
+      logger.info('💳 Starting checkout:', {
+        amount,
+        currency,
+        title,
+        useTapToPay,
+        foreignTransactionID,
+      });
+
+      const result = await NativeSumUp!.checkout(
+        amount,
+        title,
+        currency,
+        foreignTransactionID || null,
+        useTapToPay
+      );
+
+      logger.info('💳 Checkout result:', result);
+      return result;
+    } catch (error) {
+      logger.error('❌ Checkout failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Present checkout preferences
+   */
+  async presentCheckoutPreferences(): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error('Native SumUp module is not available');
+    }
+
+    try {
+      logger.info('⚙️ Presenting checkout preferences');
+      const result = await NativeSumUp!.presentCheckoutPreferences();
+      return result.success;
+    } catch (error) {
+      logger.error('❌ Failed to present checkout preferences:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get current merchant info
+   */
+  async getCurrentMerchant(): Promise<MerchantInfo | null> {
+    if (!this.isAvailable()) {
+      return null;
+    }
+
+    try {
+      const merchant = await NativeSumUp!.getCurrentMerchant();
+      logger.info('🏪 Current merchant:', merchant);
+      return merchant;
+    } catch (error) {
+      logger.error('❌ Failed to get merchant info:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Initialize and prepare for payments
+   */
+  async initialize(apiKey?: string): Promise<boolean> {
+    try {
+      // Check availability
+      if (!this.isAvailable()) {
+        logger.warn('⚠️ Native SumUp module not available');
+        return false;
+      }
+
+      // Setup SDK if API key provided
+      if (apiKey && !this.isSetup) {
+        await this.setupSDK(apiKey);
+      }
+
+      // Check if logged in
+      const loggedIn = await this.isLoggedIn();
+      if (!loggedIn) {
+        logger.info('🔐 User not logged in, will need to login');
+        return false;
+      }
+
+      // Check Tap to Pay availability
+      const tapToPay = await this.checkTapToPayAvailability();
+      logger.info('📱 Tap to Pay status:', tapToPay);
+
+      return true;
+    } catch (error) {
+      logger.error('❌ Failed to initialize SumUp:', error);
+      return false;
+    }
+  }
+}
+
+export default NativeSumUpService.getInstance();
+export { NativeSumUpService, TransactionResult, MerchantInfo };

--- a/PR4_PLAN.md
+++ b/PR4_PLAN.md
@@ -1,0 +1,51 @@
+# PR#4: Native SumUp Module Bridge Implementation
+
+## Problem
+- Native SumUp Swift module exists (`SumUpTapToPayModule.swift`) but isn't connected to JavaScript
+- App uses `sumup-react-native-alpha` package which doesn't support Tap to Pay properly
+- SumUp modal doesn't appear when payment is initiated
+- No bridge between native iOS code and React Native layer
+
+## Discovery
+Found that `ios/CashAppPOS/SumUpTapToPayModule.swift` and `.m` files exist with methods:
+- `setupSDK`
+- `checkout`
+- `checkTapToPayAvailability`
+- `performTapToPayCheckout`
+
+But these aren't being called from the JavaScript layer.
+
+## Solution
+1. Create JavaScript service to access native module
+2. Replace sumup-react-native-alpha usage with native module
+3. Implement proper error handling and callbacks
+4. Add availability checks before showing payment options
+
+## Files to Change
+- Create `src/services/NativeSumUpService.ts` - JavaScript bridge
+- Update `src/components/payment/SumUpPaymentComponent.tsx` - Use native module
+- Update `src/screens/payment/EnhancedPaymentScreen.tsx` - Check native availability
+- Verify `ios/CashAppPOS/SumUpTapToPayModule.m` - Ensure proper exports
+
+## Implementation Details
+```typescript
+// NativeSumUpService.ts
+import { NativeModules } from 'react-native';
+const { SumUpTapToPay } = NativeModules;
+
+class NativeSumUpService {
+  async isAvailable(): Promise<boolean> {
+    return await SumUpTapToPay.checkTapToPayAvailability();
+  }
+  
+  async checkout(amount: number): Promise<void> {
+    return await SumUpTapToPay.performTapToPayCheckout(amount);
+  }
+}
+```
+
+## Testing Requirements
+- Test on physical iPhone XS or later
+- Verify Tap to Pay modal appears
+- Test payment flow end-to-end
+- Check error handling for unavailable devices


### PR DESCRIPTION
## 🎯 Problem Statement
The SumUp Tap to Pay modal doesn't appear when initiating card payments. Investigation revealed that while native Swift modules exist (`SumUpTapToPayModule.swift`), they're not connected to the JavaScript layer. The app is using `sumup-react-native-alpha` package which doesn't properly support Tap to Pay on iPhone.

## 🔍 Discovery
Found existing native iOS modules that are NOT being used:
- `ios/CashAppPOS/SumUpTapToPayModule.swift` - Swift implementation
- `ios/CashAppPOS/SumUpTapToPayModule.m` - Objective-C bridge
- Methods available: `setupSDK`, `checkout`, `checkTapToPayAvailability`, `performTapToPayCheckout`

## 📋 Solution Overview
Create a proper bridge between the existing native SumUp module and React Native JavaScript layer.

## 🔧 Implementation Plan

### 1. Create JavaScript Service Bridge
```typescript
// src/services/NativeSumUpService.ts
import { NativeModules, Platform } from 'react-native';

const { SumUpTapToPay } = NativeModules;

class NativeSumUpService {
  async isAvailable(): Promise<boolean> {
    if (Platform.OS \!== 'ios') return false;
    return await SumUpTapToPay?.checkTapToPayAvailability() ?? false;
  }
  
  async setupSDK(apiKey: string): Promise<void> {
    return await SumUpTapToPay.setupSDK(apiKey);
  }
  
  async performCheckout(amount: number, currency: string): Promise<TransactionResult> {
    return await SumUpTapToPay.performTapToPayCheckout(amount, currency);
  }
}
```

### 2. Update SumUpPaymentComponent
- Remove dependency on `sumup-react-native-alpha`
- Use new `NativeSumUpService` instead
- Add proper loading and error states

### 3. Update Payment Screen
- Check native module availability on mount
- Show appropriate UI based on availability
- Handle fallback when Tap to Pay unavailable

### 4. Verify Native Module Exports
- Ensure Objective-C bridge properly exports all methods
- Add missing promise resolvers/rejecters if needed
- Test module loading in JavaScript

## 📁 Files to Create/Modify
- **Create**: `src/services/NativeSumUpService.ts` - JavaScript bridge to native module
- **Update**: `src/components/payment/SumUpPaymentComponent.tsx` - Use native module
- **Update**: `src/screens/payment/EnhancedPaymentScreen.tsx` - Check availability
- **Verify**: `ios/CashAppPOS/SumUpTapToPayModule.m` - Ensure proper exports
- **Update**: `src/types/payment.ts` - Add types for native module

## ✅ Testing Checklist
- [ ] Verify `NativeModules.SumUpTapToPay` exists in JavaScript
- [ ] Test on physical iPhone XS or later (required for Tap to Pay)
- [ ] Confirm SumUp modal appears when initiating payment
- [ ] Test successful payment flow end-to-end
- [ ] Verify error handling when device doesn't support Tap to Pay
- [ ] Test fallback to alternative payment methods
- [ ] Check module works after app restart

## 📱 Device Requirements
- Physical iPhone XS or later
- iOS 15.4 or later
- Apple Developer account with Tap to Pay approval
- Valid SumUp merchant account

## 🚀 Expected Outcome
SumUp Tap to Pay modal will properly appear and function when users select card payment, utilizing the existing native Swift implementation that's already in the codebase.

## ⚠️ Important Notes
- This connects EXISTING native code that was previously orphaned
- No new native code needs to be written
- Focuses on JavaScript-to-native bridge only

---
**This PR is part of a series addressing critical payment processing issues**

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>