### PR TITLE
Fix: Backend health check not following redirects causing demo menu to appear

### DIFF
--- a/CashApp-iOS/CashAppPOS/src/services/DataService.ts
+++ b/CashApp-iOS/CashAppPOS/src/services/DataService.ts
@@ -183,6 +183,7 @@ class DataService {
         headers: {
           'Content-Type': 'application/json',
         },
+        redirect: 'follow', // Follow 307 redirects from DigitalOcean
       });
 
       clearTimeout(timeoutId);


### PR DESCRIPTION
## 🚨 CRITICAL FIX: Menu showing demo data instead of real restaurant data

### Problem Description
The POS screen is displaying demo/mock menu items (Garlic Bread, Fish & Chips, etc.) instead of the actual Chucho's restaurant menu, even though:
- Backend is running at https://fynlopos-9eg2c.ondigitalocean.app
- Menu API endpoint returns real data when tested directly
- User reports: "Everything is just mock, pure mock"

### Root Cause Analysis 🔍
After extensive investigation across multiple files and services, discovered:

1. **Health Check Issue**: 
   - `/health` endpoint returns 200 OK ✅
   - `/api/v1/health` endpoint returns 307 redirect ⚠️
   - DataService.checkBackendAvailability() was NOT following redirects
   
2. **Cascade Effect**:
   - Health check fails → `isBackendAvailable = false`
   - Backend marked unavailable → DataService uses fallback logic
   - Fallback logic → FallbackMenuService.getDemoMenuItems()
   - Result → Demo items with IDs like 'demo-1', 'demo-2' appear

3. **Evidence**:
   ```bash
   curl https://fynlopos-9eg2c.ondigitalocean.app/health
   # Returns 200 OK
   
   curl https://fynlopos-9eg2c.ondigitalocean.app/api/v1/health
   # Returns 307 Redirect
   ```

### The Fix ✅
Added `redirect: 'follow'` option to the fetch request in checkBackendAvailability():

```typescript
const response = await fetch(`${API_CONFIG.BASE_URL}/health`, {
  method: 'GET',
  signal: controller.signal,
  headers: {
    'Content-Type': 'application/json',
  },
  redirect: 'follow', // ← NEW: Follow 307 redirects from DigitalOcean
});
```

### Testing Instructions 🧪
1. **Before Fix**: 
   - Open POS screen
   - See menu items: "Garlic Bread", "Fish & Chips", "Caesar Salad" (demo items)
   - Check console logs for "📦 Using demo menu data"

2. **After Fix**:
   - Open POS screen
   - Should see real Chucho's menu items from API
   - Check console logs for "✅ Menu items loaded and cached"
   - Verify no "demo-" prefixed IDs in menu items

### Files Changed 📝
- `src/services/DataService.ts`: Line 186 - Added `redirect: 'follow'` to fetch options

### Impact Assessment 📊
- **Severity**: HIGH - Core functionality broken (showing wrong menu)
- **Safety**: SAFE - Only adds redirect following, no logic changes
- **User Impact**: Critical - Customers see correct menu items
- **Risk**: Minimal - Single line change, easily reversible

### Related Context 📚
- Issue #397: App showing mock data in production
- Previous PRs (#611, #614, #616, #619, #620) attempted to fix but missed this root cause
- This is PR 1 of 4 comprehensive fixes identified

### Verification Commands
```bash
# Test health endpoint redirect
curl -I https://fynlopos-9eg2c.ondigitalocean.app/api/v1/health

# Verify menu API returns real data
curl https://fynlopos-9eg2c.ondigitalocean.app/api/v1/public/menu/items | jq '.data[0]'
```

### Next Steps
After this PR is merged, proceed with:
- PR #2: Fix date TypeErrors with null checks
- PR #3: Add SumUp native module diagnostics
- PR #4: Improve backend error handling

---
🤖 This detailed PR description serves as complete context for future debugging sessions