### PR TITLE
fix: Upgrade SumUp SDK to 6.2 for tap-to-pay support

### DIFF
--- a/CashApp-iOS/CashAppPOS/ios/Podfile
+++ b/CashApp-iOS/CashAppPOS/ios/Podfile
@@ -2,7 +2,7 @@
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")
 
-platform :ios, '13.4'
+platform :ios, '15.0'
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'CashAppPOS' do
@@ -21,7 +21,7 @@ target 'CashAppPOS' do
   # pod 'SquareBuyerVerificationSDK', :modular_headers => true
   
   # Official SumUp iOS SDK for Tap to Pay on iPhone
-  pod 'SumUpSDK', '~> 6.2'
+  pod 'SumUpSDK', '~> 6.1.1'
   
   post_install do |installer|
     react_native_post_install(
@@ -73,7 +73,7 @@ target 'CashAppPOS' do
     # Comprehensive fixes for Xcode 16.4 compatibility
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.4'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
         
         # Suppress non-critical warnings to prevent build hangs
         config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = "YES"

--- a/CashApp-iOS/CashAppPOS/ios/Podfile
+++ b/CashApp-iOS/CashAppPOS/ios/Podfile
@@ -21,7 +21,7 @@ target 'CashAppPOS' do
   # pod 'SquareBuyerVerificationSDK', :modular_headers => true
   
   # Official SumUp iOS SDK for Tap to Pay on iPhone
-  pod 'SumUpSDK', '~> 4.0'
+  pod 'SumUpSDK', '~> 6.2'
   
   post_install do |installer|
     react_native_post_install(

--- a/CashApp-iOS/CashAppPOS/ios/Podfile
+++ b/CashApp-iOS/CashAppPOS/ios/Podfile
@@ -2,6 +2,8 @@
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")
 
+# BREAKING CHANGE: iOS 15.0 required by SumUp SDK 6.x for tap-to-pay support
+# Previous: iOS 13.4 (supported by SDK 4.x which lacks tap-to-pay APIs)
 platform :ios, '15.0'
 install! 'cocoapods', :deterministic_uuids => false
 
@@ -21,6 +23,9 @@ target 'CashAppPOS' do
   # pod 'SquareBuyerVerificationSDK', :modular_headers => true
   
   # Official SumUp iOS SDK for Tap to Pay on iPhone
+  # Version 6.1.1 is the latest available (6.2 doesn't exist in CocoaPods)
+  # This version includes checkTapToPayAvailability and tapToPay methods (verified)
+  # Previous: SDK 4.0 which lacks tap-to-pay APIs
   pod 'SumUpSDK', '~> 6.1.1'
   
   post_install do |installer|

--- a/CashApp-iOS/CashAppPOS/ios/Podfile.lock
+++ b/CashApp-iOS/CashAppPOS/ios/Podfile.lock
@@ -507,7 +507,7 @@ PODS:
     - StripeCore (= 23.27.6)
   - sumup-react-native (0.1.36):
     - React-Core
-  - SumUpSDK (4.3.5)
+  - SumUpSDK (6.1.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -570,7 +570,7 @@ DEPENDENCIES:
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - "stripe-react-native (from `../node_modules/@stripe/stripe-react-native`)"
   - sumup-react-native (from `../node_modules/sumup-react-native-alpha`)
-  - SumUpSDK (~> 4.0)
+  - SumUpSDK (~> 6.1.1)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -778,9 +778,9 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 59ccddeacad592b09fa67e8d641340820ddb4751
   StripeUICore: 879bbf5889265db13f52fac8aad7a176ba62481f
   sumup-react-native: 2cc8eb2a1141785cdef09af64a06fc953b0a78dd
-  SumUpSDK: 4ab1160fef9ea5e0778c8ebed3a6f8e2370dbf05
+  SumUpSDK: d10627760709308f34ab9e093212c642cfff0bb7
   Yoga: ef534101bb891fb09bae657417f34d399c1efe38
 
-PODFILE CHECKSUM: fbb0189e5c567003ded755584e9a5b5cd2bad599
+PODFILE CHECKSUM: ede6df5fe64f3a5b16f37b4493bf692e89671e12
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary
Upgrades the SumUp SDK from version 4.0 to 6.1.1 (latest available) to enable tap-to-pay functionality.

## ⚠️ BREAKING CHANGE
**iOS Minimum Version Increased: 13.4 → 15.0**

This PR raises the minimum iOS deployment target from 13.4 to 15.0. This is **required** because:
- SumUp SDK 6.x requires iOS 15.0 minimum
- SumUp SDK 5.x requires iOS 14.0 minimum
- Only SDK 4.3.5 and older support iOS 13.4
- Tap-to-pay APIs only exist in SDK 6.x

**Impact**: Users on iOS 13.x and 14.x will no longer be able to install app updates.

## What Changed
- Updated `CashApp-iOS/CashAppPOS/ios/Podfile`:
  - SumUp SDK: `~> 4.0` → `~> 6.1.1` (latest available, not 6.2 which doesn't exist)
  - iOS platform: `13.4` → `15.0` (required by SDK 6.x)
- Updated `Podfile.lock` to reflect new SDK version
- Updated post_install deployment target to iOS 15.0

## Why This Change
The current SDK version 4.x does not include the required tap-to-pay APIs:
- `checkTapToPayAvailability` method (verified present in 6.1.1)
- `tapToPay` method (verified present in 6.1.1)

These APIs are confirmed available in SDK 6.1.1 headers.

## Version Clarification
- Originally planned SDK 6.2, but CocoaPods only has up to 6.1.1
- Version 6.1.1 includes all required tap-to-pay APIs
- Using `~> 6.1.1` allows patch updates (6.1.x) but not 6.2

## Testing Required
1. Run `cd CashApp-iOS/CashAppPOS/ios && pod install`
2. Build the project in Xcode
3. Verify no compilation errors
4. Test on device with iOS 15.0+

## Related Issues
- Part of comprehensive tap-to-pay fix plan
- Addresses root cause of missing API methods
- Required for tap-to-pay functionality (which itself requires iOS 15.4+)

## Phase 1.1 & 1.2 of the tap-to-pay fix plan

🤖 Generated with [Claude Code](https://claude.ai/code)